### PR TITLE
optimize lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,9 +132,7 @@ Router.prototype._insert = function (method, path, kind, params, handler, store)
 }
 
 Router.prototype.lookup = function (req, res) {
-  var i = 0
-  while (i < req.url.length && req.url.charCodeAt(i) !== 63 /* ? */ && req.url.charCodeAt(i) !== 35 /* # */) i++
-  var handle = this.find(req.method, req.url.slice(0, i))
+  var handle = this.find(req.method, sanitizeUrl(req.url))
   if (!handle) return this._defaultRoute(req, res)
   return handle.handler(req, res, handle.params, handle.store)
 }
@@ -231,3 +229,13 @@ Router.prototype._defaultRoute = function (req, res) {
 }
 
 module.exports = Router
+
+function sanitizeUrl (url) {
+  for (var i = 0; i < url.length; i++) {
+    var charCode = url.charCodeAt(i)
+    if (charCode === 63 /* ? */ || charCode === 35 /* # */) {
+      return url.slice(0, i)
+    }
+  }
+  return url
+}


### PR DESCRIPTION
avoid unecessary slice of url and I think it's also easier to read.

Using node JS 7.10 on mac OS :

From

lookup static route x 16,199,148 ops/sec ±0.61% (92 runs sampled)
lookup dynamic route x 945,503 ops/sec ±0.54% (93 runs sampled)
lookup long static route x 4,024,544 ops/sec ±0.47% (93 runs sampled)

To

lookup static route x 21,672,160 ops/sec ±0.72% (91 runs sampled)
lookup dynamic route x 1,039,106 ops/sec ±0.92% (92 runs sampled)
lookup long static route x 4,241,299 ops/sec ±0.59% (92 runs sampled)
