### PR TITLE
Basic regex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ router.on('GET', '/example/:name', () => {}))
 router.on('GET', '/other-example/*', () => {}))
 ```
 
+Regex routes are supported as well, but pay attention, regex are very expensive!
+```js
+// parametric with regex
+router.on('GET', '/test/:file(^\\d+).png', () => {}))
+```
+
 <a name="shorthand-methods"></a>
 ##### Shorthand methods
 If you want an even nicer api, you can also use the shorthand methods to declare your routes.

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ Router.prototype.on = function (method, path, handler, store) {
   for (var i = 0, len = path.length; i < len; i++) {
     // search for parametric or wildcard routes
     // parametric route
-    if (path.charCodeAt(i) === 58 || path.charCodeAt(i) === 37) {
+    if (path.charCodeAt(i) === 58) {
       j = i + 1
       this._insert(method, path.slice(0, i), 0, null, null, null)
 

--- a/node.js
+++ b/node.js
@@ -5,15 +5,17 @@
     static: 0,
     param: 1,
     matchAll: 2,
+    regex: 3
 */
 
-function Node (prefix, children, kind, map) {
+function Node (prefix, children, kind, map, regex) {
   this.prefix = prefix || '/'
   this.label = this.prefix[0]
   this.children = children || []
   this.numberOfChildren = this.children.length
   this.kind = kind || 0
   this.map = map || null
+  this.regex = regex || null
 }
 
 Node.prototype.add = function (node) {

--- a/test/regex.test.js
+++ b/test/regex.test.js
@@ -95,3 +95,33 @@ test('mixed nested route without double matching regex', t => {
 
   findMyWay.lookup({ method: 'GET', url: '/test/12/hello/test' }, null)
 })
+
+test('route with an extension regex', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => {
+      t.fail('route not matched')
+    }
+  })
+
+  findMyWay.on('GET', '/test/:file(^\\d+).png', () => {
+    t.ok('regex match')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/12.png' }, null)
+})
+
+test('route with an extension regex - no match', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => {
+      t.ok('route not matched')
+    }
+  })
+
+  findMyWay.on('GET', '/test/:file(^\\d+).png', () => {
+    t.fail('regex match')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/aa.png' }, null)
+})

--- a/test/regex.test.js
+++ b/test/regex.test.js
@@ -1,0 +1,97 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+
+test('route with matching regex', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => {
+      t.fail('route not matched')
+    }
+  })
+
+  findMyWay.on('GET', '/test/:id(^\\d+$)', () => {
+    t.ok('regex match')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/12' }, null)
+})
+
+test('route without matching regex', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => {
+      t.ok('route not matched')
+    }
+  })
+
+  findMyWay.on('GET', '/test/:id(^\\d+$)', () => {
+    t.fail('regex match')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/test' }, null)
+})
+
+test('nested route with matching regex', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => {
+      t.fail('route not matched')
+    }
+  })
+
+  findMyWay.on('GET', '/test/:id(^\\d+$)/hello', () => {
+    t.ok('regex match')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/12/hello' }, null)
+})
+
+test('mixed nested route with matching regex', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => {
+      t.fail('route not matched')
+    }
+  })
+
+  findMyWay.on('GET', '/test/:id(^\\d+$)/hello/:world', (req, res, params) => {
+    t.is(params.id, '12')
+    t.is(params.world, 'world')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/12/hello/world' }, null)
+})
+
+test('mixed nested route with double matching regex', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => {
+      t.fail('route not matched')
+    }
+  })
+
+  findMyWay.on('GET', '/test/:id(^\\d+$)/hello/:world(^\\d+$)', (req, res, params) => {
+    t.is(params.id, '12')
+    t.is(params.world, '15')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/12/hello/15' }, null)
+})
+
+test('mixed nested route without double matching regex', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => {
+      t.ok('route not matched')
+    }
+  })
+
+  findMyWay.on('GET', '/test/:id(^\\d+$)/hello/:world(^\\d+$)', (req, res, params) => {
+    t.fail('route mathed')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/12/hello/test' }, null)
+})


### PR DESCRIPTION
With this PR we introduce a basic support for regex in urls (#15).
Example:
```js
router.on('GET', '/test/:id(^\\d+$)', (req, res, params) => {
  // your logic
})
```
Currently the following is not supported:
`/test/:id(^\\d+$).png` and `/test/:id(^\\d+$)-:param(^\\d+$)`.

In Express [path-to-regexp](https://github.com/pillarjs/path-to-regexp) is used, but is not working fine for us since we are using a completely different data structure for performances reasons (same reason we are avoiding regex in the first place).

Feedbacks?
If you have some suggestion to support also the other cases, please let me know.

*ps at the moment this pr is not introducing any performances regression.*