### PR TITLE
Call find only one time

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ Router.prototype.find = function (method, path) {
     // found the route
     if (pathLen === 0 || path === prefix) {
       var handle = currentNode.getHandler(method)
-      if (!handle) return null
+      if (handle === null) break
 
       var paramNames = handle.params
       var paramsObj = {}
@@ -193,7 +193,10 @@ Router.prototype.find = function (method, path) {
     i = pathLen < prefixLen ? pathLen : prefixLen
     while (len < i && path[len] === prefix[len]) len++
 
-    if (len === prefixLen) path = path.slice(len)
+    if (len === prefixLen) {
+      path = path.slice(len)
+      pathLen = path.length
+    }
 
     node = currentNode.find(path[0])
     if (!node) return null
@@ -202,53 +205,39 @@ Router.prototype.find = function (method, path) {
     // static route
     if (kind === 0) {
       currentNode = node
-      continue
-    }
-
-    // parametric route
-    if (kind === 1) {
+    } else if (kind === 1) { // parametric route
       currentNode = node
       i = 0
-      while (i < pathLen && path.charCodeAt(i) !== 47) i++
-      decoded = fastDecode(path.slice(0, i))
+      for (; i < pathLen && path.charCodeAt(i) !== 47; i++) {}
+      decoded = fastDecode(path.substring(0, i))
       if (errored) {
-        return null
+        break
       }
       params[pindex++] = decoded
-      path = path.slice(i)
-      continue
-    }
-
-    // wildcard route
-    if (kind === 2) {
+      path = path.substring(i)
+    } else if (kind === 2) { // wildcard route
       decoded = fastDecode(path)
       if (errored) {
-        return null
+        break
       }
       params[pindex] = decoded
       currentNode = node
       path = ''
-      continue
-    }
-
-    // parametric(regex) route
-    if (kind === 3) {
+    } else if (kind === 3) { // parametric(regex) route
       currentNode = node
       i = 0
-      while (i < pathLen && path.charCodeAt(i) !== 47) i++
+      for (; i < pathLen && path.charCodeAt(i) !== 47; i++) {}
       decoded = fastDecode(path.slice(0, i))
       if (errored) {
-        return null
+        break
       }
-      if (!node.regex.test(decoded)) return
+      if (!node.regex.test(decoded)) break
       params[pindex++] = decoded
       path = path.slice(i)
-      continue
-    }
-
-    // route not found
-    if (len !== prefixLen) return null
+    } else if (len !== prefixLen) break // route not found
   }
+
+  return null
 }
 
 Router.prototype._defaultRoute = function (req, res) {

--- a/index.js
+++ b/index.js
@@ -154,6 +154,7 @@ Router.prototype.lookup = function (req, res) {
 Router.prototype.find = function (method, path) {
   var currentNode = this.tree
   var node = null
+  var kind = 0
   var decoded = null
   var pindex = 0
   var params = []
@@ -194,16 +195,18 @@ Router.prototype.find = function (method, path) {
 
     if (len === prefixLen) path = path.slice(len)
 
+    node = currentNode.find(path[0])
+    if (!node) return null
+    kind = node.kind
+
     // static route
-    node = currentNode.find(path[0], 0)
-    if (node) {
+    if (kind === 0) {
       currentNode = node
       continue
     }
 
     // parametric route
-    node = currentNode.findByKind(1)
-    if (node) {
+    if (kind === 1) {
       currentNode = node
       i = 0
       while (i < pathLen && path.charCodeAt(i) !== 47) i++
@@ -217,8 +220,7 @@ Router.prototype.find = function (method, path) {
     }
 
     // wildcard route
-    node = currentNode.findByKind(2)
-    if (node) {
+    if (kind === 2) {
       decoded = fastDecode(path)
       if (errored) {
         return null
@@ -230,8 +232,7 @@ Router.prototype.find = function (method, path) {
     }
 
     // parametric(regex) route
-    node = currentNode.findByKind(3)
-    if (node) {
+    if (kind === 3) {
       currentNode = node
       i = 0
       while (i < pathLen && path.charCodeAt(i) !== 47) i++

--- a/node.js
+++ b/node.js
@@ -23,16 +23,6 @@ Node.prototype.add = function (node) {
   this.numberOfChildren++
 }
 
-Node.prototype.find = function (label, kind) {
-  for (var i = 0; i < this.numberOfChildren; i++) {
-    var child = this.children[i]
-    if (child.label === label && child.kind === kind && (child.map || child.children.length)) {
-      return child
-    }
-  }
-  return null
-}
-
 Node.prototype.findByLabel = function (label) {
   for (var i = 0; i < this.numberOfChildren; i++) {
     var child = this.children[i]
@@ -43,11 +33,16 @@ Node.prototype.findByLabel = function (label) {
   return null
 }
 
-Node.prototype.findByKind = function (kind) {
+Node.prototype.find = function (label) {
   for (var i = 0; i < this.numberOfChildren; i++) {
     var child = this.children[i]
-    if (child.kind === kind && (child.map || child.children.length)) {
-      return child
+    if (child.map || child.children.length) {
+      if (child.label === label && child.kind === 0) {
+        return child
+      }
+      if (child.kind > 0) {
+        return child
+      }
     }
   }
   return null


### PR DESCRIPTION
As titled, there is a slightly improvements in the performances, any suggestion?

Before:
```
lookup static route x 21,752,581 ops/sec ±0.75% (90 runs sampled)
lookup dynamic route x 707,120 ops/sec ±1.14% (91 runs sampled)
lookup long static route x 2,894,137 ops/sec ±7.11% (86 runs sampled)
find static route x 31,506,022 ops/sec ±1.12% (87 runs sampled)
find dynamic route x 705,175 ops/sec ±0.85% (88 runs sampled)
find long static route x 3,994,827 ops/sec ±10.60% (83 runs sampled)
```

After:
```
lookup static route x 21,755,241 ops/sec ±0.83% (89 runs sampled)
lookup dynamic route x 717,386 ops/sec ±1.07% (90 runs sampled)
lookup long static route x 2,768,482 ops/sec ±6.72% (86 runs sampled)
find static route x 31,849,514 ops/sec ±0.79% (89 runs sampled)
find dynamic route x 737,994 ops/sec ±1.01% (87 runs sampled)
find long static route x 4,296,578 ops/sec ±10.29% (91 runs sampled)
```