### PR TITLE
Static nodes should be inserted before parametric

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ router.on('GET', '/store', (req, res, params, store) => {
   assert.equal(store, { hello: 'world' })
 }, { hello: 'world' })
 ```
-If you want to register a **parametric** path, just use the *colon* before the parameter name, if you need a **wildcard** use the *star*.
+If you want to register a **parametric** path, just use the *colon* before the parameter name, if you need a **wildcard** use the *star*.  
+*Remember that static routes are always inserted before parametric and wildcard.*
 ```js
 // parametric
 router.on('GET', '/example/:name', () => {}))

--- a/node.js
+++ b/node.js
@@ -19,6 +19,15 @@ function Node (prefix, children, kind, map, regex) {
 }
 
 Node.prototype.add = function (node) {
+  if (node.kind === 0) {
+    for (var i = 0; i < this.numberOfChildren; i++) {
+      if (this.children[i].kind > 0) {
+        this.children.splice(i, 0, node)
+        this.numberOfChildren++
+        return
+      }
+    }
+  }
   this.children.push(node)
   this.numberOfChildren++
 }

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -326,3 +326,81 @@ test('safe decodeURIComponent - wildcard', t => {
     null
   )
 })
+
+test('static routes should be inserted before parametric / 1', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/test/hello', () => {
+    t.pass('inside correct handler')
+  })
+
+  findMyWay.on('GET', '/test/:id', () => {
+    t.fail('wrong handler')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/hello' }, null)
+})
+
+test('static routes should be inserted before parametric / 2', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/test/:id', () => {
+    t.fail('wrong handler')
+  })
+
+  findMyWay.on('GET', '/test/hello', () => {
+    t.pass('inside correct handler')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/hello' }, null)
+})
+
+test('static routes should be inserted before parametric / 3', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/:id', () => {
+    t.fail('wrong handler')
+  })
+
+  findMyWay.on('GET', '/test', () => {
+    t.ok('inside correct handler')
+  })
+
+  findMyWay.on('GET', '/test/:id', () => {
+    t.fail('wrong handler')
+  })
+
+  findMyWay.on('GET', '/test/hello', () => {
+    t.ok('inside correct handler')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test' }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello' }, null)
+})
+
+test('static routes should be inserted before parametric / 4', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/:id', () => {
+    t.ok('inside correct handler')
+  })
+
+  findMyWay.on('GET', '/test', () => {
+    t.fail('wrong handler')
+  })
+
+  findMyWay.on('GET', '/test/:id', () => {
+    t.ok('inside correct handler')
+  })
+
+  findMyWay.on('GET', '/test/hello', () => {
+    t.fail('wrong handler')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/id' }, null)
+  findMyWay.lookup({ method: 'GET', url: '/id' }, null)
+})


### PR DESCRIPTION
As titled.

In this way we can support something like the following:
```js
const router = FindMyWay()

router.on('GET', '/test/:id', () => {
   throw new Error('wrong handler')
})

router.on('GET', '/test/hello', () => {
  console.log('inside correct handler')
})

router.lookup({ method: 'GET', url: '/test/hello' }, null)
```

Since this is an operation performed during the creation of the internal tree, the performances should not be affected.