### PR TITLE
Find refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,11 @@ router.on('GET', '/example/shared/nested/test', (req, res, params) => {
   assert.fail('We should not be here')
 })
 
-router.on('GET', '/example/:param/nested/test', (req, res, params) => {
+router.on('GET', '/example/:param/nested/oops', (req, res, params) => {
   assert.fail('We should not be here')
 })
 
-router.lookup({ method: 'GET', url: '/example/shared/nested/oops' }, res)
+router.lookup({ method: 'GET', url: '/example/shared/nested/oops' }, null)
 ```
 
 <a name="shorthand-methods"></a>

--- a/README.md
+++ b/README.md
@@ -106,6 +106,37 @@ In this case as parameter separator it's possible to use whatever character is n
 
 Having a route with multiple parameters may affect negatively the performance, so prefer single parameter approach whenever possible, especially on routes which are on the hot path of your application.
 
+<a name="match-order"></a>
+##### Match order
+The routes are matched in the following order:
+```
+static
+parametric
+wildcards
+parametric(regex)
+multi parametric(regex)
+```
+This means that if you register two routes, the first static and the second dynamic with a shared part of the path, the static route will always take precedence.
+For example:
+```js
+const assert = require('assert')
+const router = require('find-my-way')({
+  defaultRoute: (req, res) => {
+    assert(req.url === '/example/shared/nested/oops')
+  }
+})
+
+router.on('GET', '/example/shared/nested/test', (req, res, params) => {
+  assert.fail('We should not be here')
+})
+
+router.on('GET', '/example/:param/nested/test', (req, res, params) => {
+  assert.fail('We should not be here')
+})
+
+router.lookup({ method: 'GET', url: '/example/shared/nested/oops' }, res)
+```
+
 <a name="shorthand-methods"></a>
 ##### Shorthand methods
 If you want an even nicer api, you can also use the shorthand methods to declare your routes.

--- a/index.js
+++ b/index.js
@@ -400,7 +400,7 @@ function fastDecode (path) {
 
 function getWildcardNode (node, method, path, len) {
   if (node === null) return null
-  var decoded = fastDecode(path.slice(len))
+  var decoded = fastDecode(path.slice(-len))
   if (errored) {
     return null
   }

--- a/node.js
+++ b/node.js
@@ -40,35 +40,14 @@ Node.prototype.findByLabel = function (label) {
   return null
 }
 
-// Check in two different places the numberOfChildren and the map object
-// gives us around ~5% more speed
 Node.prototype.find = function (label, method) {
   for (var i = 0; i < this.numberOfChildren; i++) {
     var child = this.children[i]
-    if (child.numberOfChildren !== 0) {
+    if (child.numberOfChildren !== 0 || (child.map && child.map[method])) {
       if (child.label === label && child.kind === 0) {
         return child
       }
-    }
-
-    if (child.map && child.map[method]) {
-      if (child.label === label && child.kind === 0) {
-        return child
-      }
-    }
-  }
-  return null
-}
-
-Node.prototype.findByKind = function (kind, method) {
-  for (var i = 0; i < this.numberOfChildren; i++) {
-    var child = this.children[i]
-    if (child.numberOfChildren !== 0 && child.kind === kind) {
-      return child
-    }
-
-    if (child.map && child.map[method] && child.kind === kind) {
-      return child
+      if (child.kind !== 0) return child
     }
   }
   return null

--- a/node.js
+++ b/node.js
@@ -6,6 +6,8 @@
     param: 1,
     matchAll: 2,
     regex: 3
+    multi-param: 4
+      It's used for a parameter, that is followed by another parameter in the same part
 */
 
 function Node (prefix, children, kind, map, regex) {
@@ -16,9 +18,13 @@ function Node (prefix, children, kind, map, regex) {
   this.kind = kind || 0
   this.map = map || null
   this.regex = regex || null
+  this.wildcardChild = null
 }
 
 Node.prototype.add = function (node) {
+  if (node.kind === 2) {
+    this.wildcardChild = node
+  }
   this.children.push(node)
   this.children.sort((n1, n2) => n1.kind - n2.kind)
   this.numberOfChildren++

--- a/node.js
+++ b/node.js
@@ -19,16 +19,8 @@ function Node (prefix, children, kind, map, regex) {
 }
 
 Node.prototype.add = function (node) {
-  if (node.kind === 0) {
-    for (var i = 0; i < this.numberOfChildren; i++) {
-      if (this.children[i].kind > 0) {
-        this.children.splice(i, 0, node)
-        this.numberOfChildren++
-        return
-      }
-    }
-  }
   this.children.push(node)
+  this.children.sort((n1, n2) => n1.kind - n2.kind)
   this.numberOfChildren++
 }
 
@@ -51,18 +43,26 @@ Node.prototype.find = function (label, method) {
       if (child.label === label && child.kind === 0) {
         return child
       }
-      if (child.kind > 0) {
-        return child
-      }
     }
 
     if (child.map && child.map[method]) {
       if (child.label === label && child.kind === 0) {
         return child
       }
-      if (child.kind > 0) {
-        return child
-      }
+    }
+  }
+  return null
+}
+
+Node.prototype.findByKind = function (kind, method) {
+  for (var i = 0; i < this.numberOfChildren; i++) {
+    var child = this.children[i]
+    if (child.numberOfChildren !== 0 && child.kind === kind) {
+      return child
+    }
+
+    if (child.map && child.map[method] && child.kind === kind) {
+      return child
     }
   }
   return null

--- a/node.js
+++ b/node.js
@@ -16,7 +16,7 @@ function Node (prefix, children, kind, map, regex) {
   this.children = children || []
   this.numberOfChildren = this.children.length
   this.kind = kind || 0
-  this.map = map || null
+  this.map = map || {}
   this.regex = regex || null
   this.wildcardChild = null
 }
@@ -43,7 +43,7 @@ Node.prototype.findByLabel = function (label) {
 Node.prototype.find = function (label, method) {
   for (var i = 0; i < this.numberOfChildren; i++) {
     var child = this.children[i]
-    if (child.numberOfChildren !== 0 || (child.map && child.map[method])) {
+    if (child.numberOfChildren !== 0 || child.map[method]) {
       if (child.label === label && child.kind === 0) {
         return child
       }
@@ -55,16 +55,23 @@ Node.prototype.find = function (label, method) {
 
 Node.prototype.setHandler = function (method, handler, params, store) {
   if (!handler) return
-  this.map = this.map || {}
+
+  var paramsObj = {}
+  for (var i = 0; i < params.length; i++) {
+    paramsObj[params[i]] = ''
+  }
+
   this.map[method] = {
     handler: handler,
     params: params,
-    store: store || null
+    store: store || null,
+    paramsLength: params.length,
+    paramsObj: paramsObj
   }
 }
 
 Node.prototype.getHandler = function (method) {
-  return this.map ? this.map[method] : null
+  return this.map[method]
 }
 
 Node.prototype.prettyPrint = function (prefix, tail) {

--- a/test/issue-28.test.js
+++ b/test/issue-28.test.js
@@ -116,3 +116,386 @@ test('Wildcard inside a node with a static route but different method (more comp
     null
   )
 })
+
+test('Wildcard edge cases', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '/test1/foo', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/test2/foo', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('OPTIONS', '/*', (req, res, params) => {
+    t.is(req.method, 'OPTIONS')
+  })
+
+  findMyWay.lookup(
+    { method: 'OPTIONS', url: '/test1/foo' },
+    null
+  )
+})
+
+test('Wildcard edge cases same method', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('OPTIONS', '/test1/foo', (req, res, params) => {
+    t.is(req.method, 'OPTIONS')
+  })
+
+  findMyWay.on('OPTIONS', '/test2/foo', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('OPTIONS', '/*', (req, res, params) => {
+    t.is(req.url, '/test/foo')
+  })
+
+  findMyWay.lookup(
+    { method: 'OPTIONS', url: '/test1/foo' },
+    null
+  )
+
+  findMyWay.lookup(
+    { method: 'OPTIONS', url: '/test/foo' },
+    null
+  )
+})
+
+test('Wildcard and parametric edge cases', t => {
+  t.plan(3)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('OPTIONS', '/test1/foo', (req, res, params) => {
+    t.is(req.method, 'OPTIONS')
+  })
+
+  findMyWay.on('OPTIONS', '/test2/foo', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/:test/foo', (req, res, params) => {
+    t.is(req.url, '/example/foo')
+  })
+
+  findMyWay.on('OPTIONS', '/*', (req, res, params) => {
+    t.is(req.url, '/test/foo/hey')
+  })
+
+  findMyWay.lookup(
+    { method: 'OPTIONS', url: '/test1/foo' },
+    null
+  )
+
+  findMyWay.lookup(
+    { method: 'OPTIONS', url: '/test/foo/hey' },
+    null
+  )
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/example/foo' },
+    null
+  )
+})
+
+test('Mixed wildcard and static with same method', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '/foo1/bar1/baz', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/bar2/baz', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo2/bar2/baz', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.is(req.url, '/foo1/bar1/kuux')
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo1/bar1/kuux' },
+    null
+  )
+})
+
+test('Nested wildcards case - 1', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/*', (req, res, params) => {
+    t.is(req.url, '/foo1/bar1/kuux')
+  })
+
+  findMyWay.on('GET', '/foo2/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo1/bar1/kuux' },
+    null
+  )
+})
+
+test('Nested wildcards case - 2', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '/foo2/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/*', (req, res, params) => {
+    t.is(req.url, '/foo1/bar1/kuux')
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo1/bar1/kuux' },
+    null
+  )
+})
+
+test('Nested wildcards with parametric and static - 1', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/*', (req, res, params) => {
+    t.is(req.url, '/foo1/bar1/kuux')
+  })
+
+  findMyWay.on('GET', '/foo2/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo3/:param', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo4/param', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo1/bar1/kuux' },
+    null
+  )
+})
+
+test('Nested wildcards with parametric and static - 2', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo2/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo3/:param', (req, res, params) => {
+    t.is(req.url, '/foo3/bar1')
+  })
+
+  findMyWay.on('GET', '/foo4/param', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo3/bar1' },
+    null
+  )
+})
+
+test('Nested wildcards with parametric and static - 3', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo2/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo3/:param', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo4/param', (req, res, params) => {
+    t.is(req.url, '/foo4/param')
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo4/param' },
+    null
+  )
+})
+
+test('Nested wildcards with parametric and static - 4', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo2/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo3/:param', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/param', (req, res, params) => {
+    t.is(req.url, '/foo1/param')
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo1/param' },
+    null
+  )
+})
+
+test('Nested wildcards with parametric and static - 5', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/*', (req, res, params) => {
+    t.is(req.url, '/foo1/param/hello/test/long/routee')
+  })
+
+  findMyWay.on('GET', '/foo2/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo3/:param', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/param/hello/test/long/route', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo1/param/hello/test/long/routee' },
+    null
+  )
+})
+
+test('Nested wildcards with parametric and static - 6', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.is(req.url, '/foo4/param/hello/test/long/routee')
+  })
+
+  findMyWay.on('GET', '/foo1/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo2/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo3/:param', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo4/param/hello/test/long/route', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo4/param/hello/test/long/routee' },
+    null
+  )
+})

--- a/test/issue-28.test.js
+++ b/test/issue-28.test.js
@@ -528,7 +528,7 @@ test('Nested wildcards with parametric and static - 7', t => {
     t.fail('we should not be here, the url is: ' + req.url)
   })
 
-  findMyWay.on('GET', '/foo4/param/hello/test/long/route', (req, res, params) => {
+  findMyWay.on('GET', '/foo4/example/hello/test/long/route', (req, res, params) => {
     t.fail('we should not be here, the url is: ' + req.url)
   })
 

--- a/test/issue-28.test.js
+++ b/test/issue-28.test.js
@@ -499,3 +499,79 @@ test('Nested wildcards with parametric and static - 6', t => {
     null
   )
 })
+
+test('Nested wildcards with parametric and static - 7', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo2/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo3/:param', (req, res, params) => {
+    t.is(req.url, '/foo3/hello')
+  })
+
+  findMyWay.on('GET', '/foo3/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo4/param/hello/test/long/route', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo3/hello' },
+    null
+  )
+})
+
+test('Nested wildcards with parametric and static - 8', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo2/*', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo3/:param', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo3/*', (req, res, params) => {
+    t.is(req.url, '/foo3/hello/world')
+  })
+
+  findMyWay.on('GET', '/foo4/param/hello/test/long/route', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo3/hello/world' },
+    null
+  )
+})

--- a/test/issue-28.test.js
+++ b/test/issue-28.test.js
@@ -134,7 +134,7 @@ test('Wildcard edge cases', t => {
   })
 
   findMyWay.on('OPTIONS', '/*', (req, res, params) => {
-    t.is(req.method, 'OPTIONS')
+    t.is(params['*'], 'test1/foo')
   })
 
   findMyWay.lookup(
@@ -160,7 +160,7 @@ test('Wildcard edge cases same method', t => {
   })
 
   findMyWay.on('OPTIONS', '/*', (req, res, params) => {
-    t.is(req.url, '/test/foo')
+    t.is(params['*'], 'test/foo')
   })
 
   findMyWay.lookup(
@@ -191,11 +191,11 @@ test('Wildcard and parametric edge cases', t => {
   })
 
   findMyWay.on('GET', '/:test/foo', (req, res, params) => {
-    t.is(req.url, '/example/foo')
+    t.is(params.test, 'example')
   })
 
   findMyWay.on('OPTIONS', '/*', (req, res, params) => {
-    t.is(req.url, '/test/foo/hey')
+    t.is(params['*'], 'test/foo/hey')
   })
 
   findMyWay.lookup(
@@ -235,7 +235,7 @@ test('Mixed wildcard and static with same method', t => {
   })
 
   findMyWay.on('GET', '*', (req, res, params) => {
-    t.is(req.url, '/foo1/bar1/kuux')
+    t.is(params['*'], '/foo1/bar1/kuux')
   })
 
   findMyWay.lookup(
@@ -257,7 +257,7 @@ test('Nested wildcards case - 1', t => {
   })
 
   findMyWay.on('GET', '/foo1/*', (req, res, params) => {
-    t.is(req.url, '/foo1/bar1/kuux')
+    t.is(params['*'], 'bar1/kuux')
   })
 
   findMyWay.on('GET', '/foo2/*', (req, res, params) => {
@@ -283,7 +283,7 @@ test('Nested wildcards case - 2', t => {
   })
 
   findMyWay.on('GET', '/foo1/*', (req, res, params) => {
-    t.is(req.url, '/foo1/bar1/kuux')
+    t.is(params['*'], 'bar1/kuux')
   })
 
   findMyWay.on('GET', '*', (req, res, params) => {
@@ -309,7 +309,7 @@ test('Nested wildcards with parametric and static - 1', t => {
   })
 
   findMyWay.on('GET', '/foo1/*', (req, res, params) => {
-    t.is(req.url, '/foo1/bar1/kuux')
+    t.is(params['*'], 'bar1/kuux')
   })
 
   findMyWay.on('GET', '/foo2/*', (req, res, params) => {
@@ -351,7 +351,7 @@ test('Nested wildcards with parametric and static - 2', t => {
   })
 
   findMyWay.on('GET', '/foo3/:param', (req, res, params) => {
-    t.is(req.url, '/foo3/bar1')
+    t.is(params.param, 'bar1')
   })
 
   findMyWay.on('GET', '/foo4/param', (req, res, params) => {
@@ -445,7 +445,7 @@ test('Nested wildcards with parametric and static - 5', t => {
   })
 
   findMyWay.on('GET', '/foo1/*', (req, res, params) => {
-    t.is(req.url, '/foo1/param/hello/test/long/routee')
+    t.is(params['*'], 'param/hello/test/long/routee')
   })
 
   findMyWay.on('GET', '/foo2/*', (req, res, params) => {
@@ -475,7 +475,7 @@ test('Nested wildcards with parametric and static - 6', t => {
   })
 
   findMyWay.on('GET', '*', (req, res, params) => {
-    t.is(req.url, '/foo4/param/hello/test/long/routee')
+    t.is(params['*'], '/foo4/param/hello/test/long/routee')
   })
 
   findMyWay.on('GET', '/foo1/*', (req, res, params) => {
@@ -521,7 +521,7 @@ test('Nested wildcards with parametric and static - 7', t => {
   })
 
   findMyWay.on('GET', '/foo3/:param', (req, res, params) => {
-    t.is(req.url, '/foo3/hello')
+    t.is(params.param, 'hello')
   })
 
   findMyWay.on('GET', '/foo3/*', (req, res, params) => {
@@ -563,7 +563,7 @@ test('Nested wildcards with parametric and static - 8', t => {
   })
 
   findMyWay.on('GET', '/foo3/*', (req, res, params) => {
-    t.is(req.url, '/foo3/hello/world')
+    t.is(params['*'], 'hello/world')
   })
 
   findMyWay.on('GET', '/foo4/param/hello/test/long/route', (req, res, params) => {

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -437,3 +437,19 @@ test('Static parametric with shared part of the path', t => {
   findMyWay.lookup({ method: 'GET', url: '/example/shared/nested/oops' }, null)
   findMyWay.lookup({ method: 'GET', url: '/example/other/nested/test' }, null)
 })
+
+test('parametric route with different method', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/test/:id', (req, res, params) => {
+    t.is(params.id, 'hello')
+  })
+
+  findMyWay.on('POST', '/test/:other', (req, res, params) => {
+    t.is(params.other, 'world')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/hello' }, null)
+  findMyWay.lookup({ method: 'POST', url: '/test/world' }, null)
+})

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -416,3 +416,24 @@ test('static routes should be inserted before parametric / 4', t => {
   findMyWay.lookup({ method: 'GET', url: '/test/id' }, null)
   findMyWay.lookup({ method: 'GET', url: '/id' }, null)
 })
+
+test('Static parametric with shared part of the path', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.is(req.url, '/example/shared/nested/oops')
+    }
+  })
+
+  findMyWay.on('GET', '/example/shared/nested/test', (req, res, params) => {
+    t.fail('We should not be here')
+  })
+
+  findMyWay.on('GET', '/example/:param/nested/test', (req, res, params) => {
+    t.is(params.param, 'other')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/example/shared/nested/oops' }, null)
+  findMyWay.lookup({ method: 'GET', url: '/example/other/nested/test' }, null)
+})

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -430,12 +430,12 @@ test('Static parametric with shared part of the path', t => {
     t.fail('We should not be here')
   })
 
-  findMyWay.on('GET', '/example/:param/nested/test', (req, res, params) => {
+  findMyWay.on('GET', '/example/:param/nested/oops', (req, res, params) => {
     t.is(params.param, 'other')
   })
 
   findMyWay.lookup({ method: 'GET', url: '/example/shared/nested/oops' }, null)
-  findMyWay.lookup({ method: 'GET', url: '/example/other/nested/test' }, null)
+  findMyWay.lookup({ method: 'GET', url: '/example/other/nested/oops' }, null)
 })
 
 test('parametric route with different method', t => {


### PR DESCRIPTION
After a lot of work I come up with two solutions:
1. `find2` is a recursive function, we cover all the test cases but we are slower, around 1%-5% leff compared to the iterative version
2. `find` is iterative, we have two trees, one for the static/parametric routes and one for the wildcards. If the static/parametric fails if we know that there is a wildcard route we search it inside the wildcard tree. All the changes inside the `insert` and `_insert` function has been done to support this.

Sorry about the following, two different PRs were a little bit hard to handle:
If you want to test the recursive function:
1. rename `find2`in `find` and viceversa.
2. uncomment line 141

As you can see the recursive version works in all the cases, while the iterative fails in case of nested static nodes. We could fix the iterative version by using a stack, but I'm pretty sure that the performances will slow down a lot.

I'm open to feedbacks and suggestions to improve this, sorry again for the "mess" :P

cc @brunoscopelliti 

ps if you think that two separate pr are better, let me know and I'll working out :P