### PR TITLE
Fixed wrong params object reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -209,17 +209,18 @@ Router.prototype.find = function find (method, path) {
     if (pathLen === 0 || path === prefix) {
       var handle = currentNode.getHandler(method)
       if (handle !== undefined) {
+        var paramsObj = {}
         if (handle.paramsLength > 0) {
           var paramNames = handle.params
 
           for (i = 0; i < handle.paramsLength; i++) {
-            handle.paramsObj[paramNames[i]] = params[i]
+            paramsObj[paramNames[i]] = params[i]
           }
         }
 
         return {
           handler: handle.handler,
-          params: handle.paramsObj,
+          params: paramsObj,
           store: handle.store
         }
       }

--- a/node.js
+++ b/node.js
@@ -56,17 +56,11 @@ Node.prototype.find = function (label, method) {
 Node.prototype.setHandler = function (method, handler, params, store) {
   if (!handler) return
 
-  var paramsObj = {}
-  for (var i = 0; i < params.length; i++) {
-    paramsObj[params[i]] = ''
-  }
-
   this.map[method] = {
     handler: handler,
     params: params,
     store: store || null,
-    paramsLength: params.length,
-    paramsObj: paramsObj
+    paramsLength: params.length
   }
 }
 

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -453,3 +453,25 @@ test('parametric route with different method', t => {
   findMyWay.lookup({ method: 'GET', url: '/test/hello' }, null)
   findMyWay.lookup({ method: 'POST', url: '/test/world' }, null)
 })
+
+test('params does not keep the object reference', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+  var first = true
+
+  findMyWay.on('GET', '/test/:id', (req, res, params) => {
+    if (first) {
+      setTimeout(() => {
+        t.is(params.id, 'hello')
+      }, 10)
+    } else {
+      setTimeout(() => {
+        t.is(params.id, 'world')
+      }, 10)
+    }
+    first = false
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/hello' }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/world' }, null)
+})


### PR DESCRIPTION
As titled.

In some edge cases could happen that we overwrite the `paramsObj` stored in the node map object, and because of the reference of the object an user could have an hard time to figure out what is happening.
This pr fixed that.