### PR TITLE
Fixes 46

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,12 +276,6 @@ Router.prototype.find = function find (method, path) {
       pathLen = path.length
     }
 
-    // if exist, save the wildcard child
-    if (currentNode.wildcardChild !== null) {
-      wildcardNode = currentNode.wildcardChild
-      pathLenWildcard = pathLen
-    }
-
     var node = currentNode.find(path[0], method)
     if (node === null) {
       node = currentNode.parametricBrother
@@ -296,12 +290,23 @@ Router.prototype.find = function find (method, path) {
 
     // static route
     if (kind === 0) {
+      // if exist, save the wildcard child
+      if (currentNode.wildcardChild !== null) {
+        wildcardNode = currentNode.wildcardChild
+        pathLenWildcard = pathLen
+      }
       currentNode = node
       continue
     }
 
     if (len !== prefixLen) {
       return getWildcardNode(wildcardNode, method, originalPath, pathLenWildcard)
+    }
+
+    // if exist, save the wildcard child
+    if (currentNode.wildcardChild !== null) {
+      wildcardNode = currentNode.wildcardChild
+      pathLenWildcard = pathLen
     }
 
     // parametric route
@@ -364,6 +369,8 @@ Router.prototype.find = function find (method, path) {
       path = path.slice(i)
       continue
     }
+
+    wildcardNode = null
   }
 }
 

--- a/test/issue-46.test.js
+++ b/test/issue-46.test.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+
+test('If the prefixLen is higher than the pathLen we should not save the wildcard child', t => {
+  t.plan(3)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.get('/static/*', () => {})
+
+  t.deepEqual(findMyWay.find('GET', '/static/').params, { '*': '' })
+  t.deepEqual(findMyWay.find('GET', '/static/hello').params, { '*': 'hello' })
+  t.deepEqual(findMyWay.find('GET', '/static'), null)
+})
+
+test('If the prefixLen is higher than the pathLen we should not save the wildcard child (mixed routes)', t => {
+  t.plan(3)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.get('/static/*', () => {})
+  findMyWay.get('/simple', () => {})
+  findMyWay.get('/simple/:bar', () => {})
+  findMyWay.get('/hello', () => {})
+
+  t.deepEqual(findMyWay.find('GET', '/static/').params, { '*': '' })
+  t.deepEqual(findMyWay.find('GET', '/static/hello').params, { '*': 'hello' })
+  t.deepEqual(findMyWay.find('GET', '/static'), null)
+})
+
+test('If the prefixLen is higher than the pathLen we should not save the wildcard child (with a root wildcard)', t => {
+  t.plan(3)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.get('*', () => {})
+  findMyWay.get('/static/*', () => {})
+  findMyWay.get('/simple', () => {})
+  findMyWay.get('/simple/:bar', () => {})
+  findMyWay.get('/hello', () => {})
+
+  t.deepEqual(findMyWay.find('GET', '/static/').params, { '*': '' })
+  t.deepEqual(findMyWay.find('GET', '/static/hello').params, { '*': 'hello' })
+  t.deepEqual(findMyWay.find('GET', '/static').params, { '*': '/static' })
+})
+
+test('If the prefixLen is higher than the pathLen we should not save the wildcard child (404)', t => {
+  t.plan(4)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.get('/static/*', () => {})
+  findMyWay.get('/simple', () => {})
+  findMyWay.get('/simple/:bar', () => {})
+  findMyWay.get('/hello', () => {})
+
+  t.deepEqual(findMyWay.find('GET', '/stati'), null)
+  t.deepEqual(findMyWay.find('GET', '/staticc'), null)
+  t.deepEqual(findMyWay.find('GET', '/stati/hello'), null)
+  t.deepEqual(findMyWay.find('GET', '/staticc/hello'), null)
+})


### PR DESCRIPTION
As titled.
The problem was that we were saving the wildcard node even if there was no matching node, just by moving the wildcard child check the issue is fixed.

@nwoltman can you confirm that this fixes your issue?