### PR TITLE
Add support for ignoring trailing slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A crazy fast HTTP router, internally uses an highly performant [Radix Tree](https://en.wikipedia.org/wiki/Radix_tree) (aka compact [Prefix Tree](https://en.wikipedia.org/wiki/Trie)), supports route params, wildcards, and it's framework independent.
 
-If you want to see a benchmark comparison with the most commonly used routers, see [here](https://github.com/delvedor/router-benchmark).  
+If you want to see a benchmark comparison with the most commonly used routers, see [here](https://github.com/delvedor/router-benchmark).<br>
 Do you need a real-world example that uses this router? Check out [Fastify](https://github.com/fastify/fastify).
 
 <a name="install"></a>
@@ -37,7 +37,7 @@ server.listen(3000, err => {
 ## API
 <a name="constructor"></a>
 #### FindMyway([options])
-Instance a new router.  
+Instance a new router.<br>
 You can pass a default route with the option `defaultRoute`.
 ```js
 const router = require('find-my-way')({
@@ -46,6 +46,18 @@ const router = require('find-my-way')({
     res.end()
   }
 })
+```
+
+Trailing slashes can be ignored by supplying the `trimeTrailingSlash` option:
+```js
+const router = require('find-my-way')({
+  trimTrailingSlash: true
+})
+function handler (req, res, params) {
+  res.send('foo')
+}
+// maps "/foo/" and "/foo" to `handler`
+router.on('GET', '/foo/', handler)
 ```
 
 <a name="on"></a>
@@ -197,8 +209,8 @@ router.all(path, handler [, store])
 
 <a name="lookup"></a>
 #### lookup(request, response)
-Start a new search, `request` and `response` are the server req/res objects.  
-If a route is found it will automatically called the handler, otherwise the default route will be called.  
+Start a new search, `request` and `response` are the server req/res objects.<br>
+If a route is found it will automatically called the handler, otherwise the default route will be called.<br>
 The url is sanitized internally, all the parameters and wildcards are decoded automatically.
 ```js
 router.lookup(req, res)
@@ -206,7 +218,7 @@ router.lookup(req, res)
 
 <a name="find"></a>
 #### find(method, path)
-Return (if present) the route registered in *method:path*.  
+Return (if present) the route registered in *method:path*.<br>
 The path must be sanitized, all the parameters and wildcards are decoded automatically.
 ```js
 router.find('GET', '/example')
@@ -232,12 +244,12 @@ console.log(findMyWay.prettyPrint())
 <a name="acknowledgements"></a>
 ## Acknowledgements
 
-This project is kindly sponsored by [LetzDoIt](http://www.letzdoitapp.com/).  
+This project is kindly sponsored by [LetzDoIt](http://www.letzdoitapp.com/).<br>
 It is inspired by the [echo](https://github.com/labstack/echo) router, some parts have been extracted from [trekjs](https://github.com/trekjs) router.
 
 <a name="license"></a>
 ## License
-**[find-my-way - MIT](https://github.com/delvedor/find-my-way/blob/master/LICENSE)**  
+**[find-my-way - MIT](https://github.com/delvedor/find-my-way/blob/master/LICENSE)**<br>
 **[trekjs/router - MIT](https://github.com/trekjs/router/blob/master/LICENSE)**
 
 Copyright © 2017 Tomas Della Vedova

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ const router = require('find-my-way')({
 })
 ```
 
-Trailing slashes can be ignored by supplying the `trimeTrailingSlash` option:
+Trailing slashes can be ignored by supplying the `ignoreTrailingSlash` option:
 ```js
 const router = require('find-my-way')({
-  trimTrailingSlash: true
+  ignoreTrailingSlash: true
 })
 function handler (req, res, params) {
   res.send('foo')

--- a/index.js
+++ b/index.js
@@ -34,20 +34,20 @@ function Router (opts) {
     this.defaultRoute = opts.defaultRoute
   }
 
-  this.trimTrailingSlash = opts.trimTrailingSlash || false
+  this.ignoreTrailingSlash = opts.ignoreTrailingSlash || false
   this.tree = new Node()
   this.routes = []
 }
 
 Router.prototype.on = function on (method, path, handler, store) {
   const register = (m, p, h, s) => {
-    if (this.trimTrailingSlash && p.endsWith('/')) {
+    if (this.ignoreTrailingSlash && p.endsWith('/')) {
       this._on(m, p, h, s)
       this._on(m, p.slice(0, -1), h, s)
-    } else if (this.trimTrailingSlash && p.endsWith('/') === false) {
+    } else if (this.ignoreTrailingSlash && p.endsWith('/') === false) {
       this._on(m, p, h, s)
       this._on(m, p + '/', h, s)
-    } else if (!this.trimTrailingSlash) {
+    } else if (!this.ignoreTrailingSlash) {
       this._on(m, p, h, s)
     }
   }
@@ -229,9 +229,9 @@ Router.prototype.off = function off (method, path) {
   assert(path[0] === '/' || path[0] === '*', 'The first character of a path should be `/` or `*`')
 
   // Rebuild tree without the specific route
-  const trimTrailingSlash = this.trimTrailingSlash
+  const ignoreTrailingSlash = this.ignoreTrailingSlash
   var newRoutes = self.routes.filter(function (route) {
-    if (!trimTrailingSlash) {
+    if (!ignoreTrailingSlash) {
       return !(method === route.method && path === route.path)
     }
     if (path.endsWith('/')) {
@@ -241,7 +241,7 @@ Router.prototype.off = function off (method, path) {
     const routeMatches = path === route.path || (path + '/') === route.path
     return !(method === route.method && routeMatches)
   })
-  if (trimTrailingSlash) {
+  if (ignoreTrailingSlash) {
     newRoutes = newRoutes.filter(function (route, i, ar) {
       if (route.path.endsWith('/') && i < ar.length - 1) {
         return route.path.slice(0, -1) !== ar[i + 1].path

--- a/index.js
+++ b/index.js
@@ -41,15 +41,16 @@ function Router (opts) {
 
 Router.prototype.on = function on (method, path, handler, store) {
   const register = (m, p, h, s) => {
+    if (!this.ignoreTrailingSlash || path === '/' || path.endsWith('*')) {
+      return this._on(m, p, h, s)
+    }
     if (this.ignoreTrailingSlash && p.endsWith('/')) {
       this._on(m, p, h, s)
       this._on(m, p.slice(0, -1), h, s)
-    } else if (this.ignoreTrailingSlash && p.endsWith('/') === false) {
-      this._on(m, p, h, s)
-      this._on(m, p + '/', h, s)
-    } else if (!this.ignoreTrailingSlash) {
-      this._on(m, p, h, s)
+      return
     }
+    this._on(m, p, h, s)
+    this._on(m, p + '/', h, s)
   }
   if (Array.isArray(method)) {
     for (var k = 0; k < method.length; k++) {

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -67,6 +67,19 @@ test('register a route with multiple methods', t => {
   findMyWay.lookup({ method: 'POST', url: '/test' }, null)
 })
 
+test('does not register /test/*/ when ignoreTrailingSlash is true', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    ignoreTrailingSlash: true
+  })
+
+  findMyWay.on('GET', '/test/*', () => {})
+  t.is(
+    findMyWay.routes.filter((r) => r.path.includes('/test')).length,
+    1
+  )
+})
+
 test('off throws for invalid method', t => {
   t.plan(1)
   const findMyWay = FindMyWay()

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -128,10 +128,10 @@ test('off with nested wildcards with parametric and static', t => {
   )
 })
 
-test('off removes all routes when trimTrailingSlash is true', t => {
+test('off removes all routes when ignoreTrailingSlash is true', t => {
   t.plan(6)
   const findMyWay = FindMyWay({
-    trimTrailingSlash: true
+    ignoreTrailingSlash: true
   })
 
   findMyWay.on('GET', '/test1/', () => {})

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -128,6 +128,33 @@ test('off with nested wildcards with parametric and static', t => {
   )
 })
 
+test('off removes all routes when trimTrailingSlash is true', t => {
+  t.plan(6)
+  const findMyWay = FindMyWay({
+    trimTrailingSlash: true
+  })
+
+  findMyWay.on('GET', '/test1/', () => {})
+  t.is(findMyWay.routes.length, 2)
+
+  findMyWay.on('GET', '/test2', () => {})
+  t.is(findMyWay.routes.length, 4)
+
+  findMyWay.off('GET', '/test1')
+  t.is(findMyWay.routes.length, 2)
+  t.is(
+    findMyWay.routes.filter((r) => r.path === '/test2').length,
+    1
+  )
+  t.is(
+    findMyWay.routes.filter((r) => r.path === '/test2/').length,
+    1
+  )
+
+  findMyWay.off('GET', '/test2/')
+  t.is(findMyWay.routes.length, 0)
+})
+
 test('deregister a route without children', t => {
   t.plan(2)
   const findMyWay = FindMyWay()

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -112,3 +112,113 @@ test('automatic default route', t => {
     })
   })
 })
+
+test('maps two routes when trailing slash should be trimmed', t => {
+  t.plan(25)
+  const findMyWay = FindMyWay({
+    trimTrailingSlash: true
+  })
+
+  findMyWay.on('GET', '/test/', (req, res, params) => {
+    t.ok(req)
+    t.ok(res)
+    t.ok(params)
+    res.end('test')
+  })
+
+  findMyWay.on('GET', '/othertest', (req, res, params) => {
+    t.ok(req)
+    t.ok(res)
+    t.ok(params)
+    res.end('othertest')
+  })
+
+  const server = http.createServer((req, res) => {
+    findMyWay.lookup(req, res)
+  })
+
+  server.listen(0, err => {
+    t.error(err)
+    server.unref()
+
+    const baseURL = 'http://localhost:' + server.address().port
+
+    request({
+      method: 'GET',
+      uri: baseURL + '/test/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(body, 'test')
+    })
+
+    request({
+      method: 'GET',
+      uri: baseURL + '/test'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(body, 'test')
+    })
+
+    request({
+      method: 'GET',
+      uri: baseURL + '/othertest'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(body, 'othertest')
+    })
+
+    request({
+      method: 'GET',
+      uri: baseURL + '/othertest/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(body, 'othertest')
+    })
+  })
+})
+
+test('does not trim trailing slash when trimTrailingSlash is false', t => {
+  t.plan(9)
+  const findMyWay = FindMyWay({
+    trimTrailingSlash: false
+  })
+
+  findMyWay.on('GET', '/test/', (req, res, params) => {
+    t.ok(req)
+    t.ok(res)
+    t.ok(params)
+    res.end('test')
+  })
+
+  const server = http.createServer((req, res) => {
+    findMyWay.lookup(req, res)
+  })
+
+  server.listen(0, err => {
+    t.error(err)
+    server.unref()
+
+    const baseURL = 'http://localhost:' + server.address().port
+
+    request({
+      method: 'GET',
+      uri: baseURL + '/test/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(body, 'test')
+    })
+
+    request({
+      method: 'GET',
+      uri: baseURL + '/test'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 404)
+    })
+  })
+})

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -222,3 +222,45 @@ test('does not trim trailing slash when ignoreTrailingSlash is false', t => {
     })
   })
 })
+
+test('does not map // when ignoreTrailingSlash is true', t => {
+  t.plan(9)
+  const findMyWay = FindMyWay({
+    ignoreTrailingSlash: false
+  })
+
+  findMyWay.on('GET', '/', (req, res, params) => {
+    t.ok(req)
+    t.ok(res)
+    t.ok(params)
+    res.end('test')
+  })
+
+  const server = http.createServer((req, res) => {
+    findMyWay.lookup(req, res)
+  })
+
+  server.listen(0, err => {
+    t.error(err)
+    server.unref()
+
+    const baseURL = 'http://localhost:' + server.address().port
+
+    request({
+      method: 'GET',
+      uri: baseURL + '/'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+      t.strictEqual(body, 'test')
+    })
+
+    request({
+      method: 'GET',
+      uri: baseURL + '//'
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 404)
+    })
+  })
+})

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -116,7 +116,7 @@ test('automatic default route', t => {
 test('maps two routes when trailing slash should be trimmed', t => {
   t.plan(25)
   const findMyWay = FindMyWay({
-    trimTrailingSlash: true
+    ignoreTrailingSlash: true
   })
 
   findMyWay.on('GET', '/test/', (req, res, params) => {
@@ -181,10 +181,10 @@ test('maps two routes when trailing slash should be trimmed', t => {
   })
 })
 
-test('does not trim trailing slash when trimTrailingSlash is false', t => {
+test('does not trim trailing slash when ignoreTrailingSlash is false', t => {
   t.plan(9)
   const findMyWay = FindMyWay({
-    trimTrailingSlash: false
+    ignoreTrailingSlash: false
   })
 
   findMyWay.on('GET', '/test/', (req, res, params) => {


### PR DESCRIPTION
This PR implements the logic described in https://github.com/fastify/fastify/issues/584#issuecomment-355134797

```js
const router = require('find-my-way')({
  trimTrailingSlash: true
})

function handler (req, res, params) {
  res.send('foo')
}

// maps "/foo/" and "/foo" to `handler`
router.on('GET', '/foo/', handler)
```