### PR TITLE
Use constants for node types instead of magic numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,6 @@
 'use strict'
 
 /*
-  Node type
-    static: 0,
-    param: 1,
-    matchAll: 2,
-    regex: 3
-    multi-param: 4
-      It's used for a parameter, that is followed by another parameter in the same part
-
   Char codes:
     '#': 35
     '*': 42
@@ -20,6 +12,7 @@
 
 const assert = require('assert')
 const Node = require('./node')
+const NODE_TYPES = Node.prototype.types
 const httpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS', 'TRACE', 'CONNECT']
 var errored = false
 
@@ -86,7 +79,7 @@ Router.prototype._on = function _on (method, path, handler, store) {
     // search for parametric or wildcard routes
     // parametric route
     if (path.charCodeAt(i) === 58) {
-      var nodeType = 1
+      var nodeType = NODE_TYPES.PARAM
       j = i + 1
       this._insert(method, path.slice(0, i), 0, null, null, null, null)
 
@@ -105,9 +98,9 @@ Router.prototype._on = function _on (method, path, handler, store) {
       }
 
       if (isRegex && (i === len || path.charCodeAt(i) === 47)) {
-        nodeType = 3
+        nodeType = NODE_TYPES.REGEX
       } else if (i < len && path.charCodeAt(i) !== 47) {
-        nodeType = 4
+        nodeType = NODE_TYPES.MULTI_PARAM
       }
 
       var parameter = path.slice(j, i)
@@ -169,7 +162,7 @@ Router.prototype._insert = function _insert (method, path, kind, params, handler
       currentNode.prefix = prefix.slice(0, len)
       currentNode.label = currentNode.prefix[0]
       currentNode.map = {}
-      currentNode.kind = 0
+      currentNode.kind = NODE_TYPES.STATIC
       currentNode.regex = null
       currentNode.wildcardChild = null
 
@@ -324,7 +317,7 @@ Router.prototype.find = function find (method, path) {
     var kind = node.kind
 
     // static route
-    if (kind === 0) {
+    if (kind === NODE_TYPES.STATIC) {
       // if exist, save the wildcard child
       if (currentNode.wildcardChild !== null) {
         wildcardNode = currentNode.wildcardChild
@@ -345,7 +338,7 @@ Router.prototype.find = function find (method, path) {
     }
 
     // parametric route
-    if (kind === 1) {
+    if (kind === NODE_TYPES.PARAM) {
       currentNode = node
       i = 0
       while (i < pathLen && path.charCodeAt(i) !== 47) i++
@@ -359,7 +352,7 @@ Router.prototype.find = function find (method, path) {
     }
 
     // wildcard route
-    if (kind === 2) {
+    if (kind === NODE_TYPES.MATCH_ALL) {
       decoded = fastDecode(path)
       if (errored) {
         return null
@@ -371,7 +364,7 @@ Router.prototype.find = function find (method, path) {
     }
 
     // parametric(regex) route
-    if (kind === 3) {
+    if (kind === NODE_TYPES.REGEX) {
       currentNode = node
       i = 0
       while (i < pathLen && path.charCodeAt(i) !== 47) i++
@@ -386,7 +379,7 @@ Router.prototype.find = function find (method, path) {
     }
 
     // multiparametric route
-    if (kind === 4) {
+    if (kind === NODE_TYPES.MULTI_PARAM) {
       currentNode = node
       i = 0
       if (node.regex) {

--- a/node.js
+++ b/node.js
@@ -30,7 +30,7 @@ Node.prototype.add = function (node) {
     this.wildcardChild = node
   }
 
-  if ([this.types.PARAM, this.types.REGEX, this.types.MULTI_PARAM].includes(node.kind)) {
+  if ([this.types.PARAM, this.types.REGEX, this.types.MULTI_PARAM].indexOf(node.kind) > -1) {
     for (var i = 0; i < this.numberOfChildren; i++) {
       if (this.children[i].kind === 0) {
         this.children[i].parametricBrother = node

--- a/node.js
+++ b/node.js
@@ -1,33 +1,36 @@
 'use strict'
 
-/*
-  Node type
-    static: 0,
-    param: 1,
-    matchAll: 2,
-    regex: 3
-    multi-param: 4
-      It's used for a parameter, that is followed by another parameter in the same part
-*/
+const types = {
+  STATIC: 0,
+  PARAM: 1,
+  MATCH_ALL: 2,
+  REGEX: 3,
+  // It's used for a parameter, that is followed by another parameter in the same part
+  MULTI_PARAM: 4
+}
 
 function Node (prefix, children, kind, map, regex) {
   this.prefix = prefix || '/'
   this.label = this.prefix[0]
   this.children = children || []
   this.numberOfChildren = this.children.length
-  this.kind = kind || 0
+  this.kind = kind || this.types.STATIC
   this.map = map || {}
   this.regex = regex || null
   this.wildcardChild = null
   this.parametricBrother = null
 }
 
+Object.defineProperty(Node.prototype, 'types', {
+  value: types
+})
+
 Node.prototype.add = function (node) {
-  if (node.kind === 2) {
+  if (node.kind === this.types.MATCH_ALL) {
     this.wildcardChild = node
   }
 
-  if (node.kind === 1 || node.kind === 3 || node.kind === 4) {
+  if ([this.types.PARAM, this.types.REGEX, this.types.MULTI_PARAM].includes(node.kind)) {
     for (var i = 0; i < this.numberOfChildren; i++) {
       if (this.children[i].kind === 0) {
         this.children[i].parametricBrother = node


### PR DESCRIPTION
This PR replaces all of the instances like `node.kind === 0` with `node.kind === NODE_TYPES.STATIC`. This is clearer to the reader, and thus to people trying to contribute to the project.

My system is a mid-2012 MacBook Pro, so it isn't very fast. But I don't see any real discrepancy in the benchmarks:

**master:**
```
lookup static route x 22,606,815 ops/sec ±1.10% (85 runs sampled)
lookup dynamic route x 1,406,844 ops/sec ±0.99% (89 runs sampled)
lookup dynamic multi-parametric route x 776,795 ops/sec ±0.99% (87 runs sampled)
lookup dynamic multi-parametric route with regex x 689,269 ops/sec ±0.99% (89 runs sampled)
lookup long static route x 2,919,538 ops/sec ±1.03% (89 runs sampled)
find static route x 27,170,227 ops/sec ±0.89% (87 runs sampled)
find dynamic route x 1,490,351 ops/sec ±1.77% (89 runs sampled)
find dynamic multi-parametric route x 832,010 ops/sec ±0.89% (91 runs sampled)
find dynamic multi-parametric route with regex x 715,763 ops/sec ±1.00% (87 runs sampled)
find long static route x 3,852,285 ops/sec ±0.82% (91 runs sampled)
```
**branch:**
```
lookup static route x 22,736,075 ops/sec ±1.77% (85 runs sampled)
lookup dynamic route x 1,415,499 ops/sec ±0.90% (91 runs sampled)
lookup dynamic multi-parametric route x 733,222 ops/sec ±1.10% (87 runs sampled)
lookup dynamic multi-parametric route with regex x 701,346 ops/sec ±0.96% (91 runs sampled)
lookup long static route x 2,912,104 ops/sec ±1.06% (91 runs sampled)
find static route x 26,740,260 ops/sec ±1.01% (86 runs sampled)
find dynamic route x 1,489,647 ops/sec ±1.15% (89 runs sampled)
find dynamic multi-parametric route x 829,876 ops/sec ±0.96% (88 runs sampled)
find dynamic multi-parametric route with regex x 736,822 ops/sec ±0.92% (90 runs sampled)
find long static route x 3,729,310 ops/sec ±1.11% (84 runs sampled)
```