### PR TITLE
Improve error message when route is already declared

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,6 +138,7 @@ Router.prototype._on = function _on (method, path, handler, store) {
 }
 
 Router.prototype._insert = function _insert (method, path, kind, params, handler, store, regex) {
+  const route = path
   var currentNode = this.tree
   var prefix = ''
   var pathLen = 0
@@ -175,7 +176,7 @@ Router.prototype._insert = function _insert (method, path, kind, params, handler
 
       if (len === pathLen) {
         // add the handler to the parent node
-        assert(!currentNode.getHandler(method), `Method '${method}' already declared for route '${path}'`)
+        assert(!currentNode.getHandler(method), `Method '${method}' already declared for route '${route}'`)
         currentNode.setHandler(method, handler, params, store)
         currentNode.kind = kind
       } else {
@@ -200,7 +201,7 @@ Router.prototype._insert = function _insert (method, path, kind, params, handler
       currentNode.add(node)
     } else if (handler) {
       // the node already exist
-      assert(!currentNode.getHandler(method), `Method '${method}' already declared for route '${path}'`)
+      assert(!currentNode.getHandler(method), `Method '${method}' already declared for route '${route}'`)
       currentNode.setHandler(method, handler, params, store)
     }
     return

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -121,7 +121,7 @@ test('Method already declared', t => {
     findMyWay.on('GET', '/test', () => {})
     t.fail('method already declared')
   } catch (e) {
-    t.is(e.message, `Method 'GET' already declared for route 'test'`)
+    t.is(e.message, `Method 'GET' already declared for route '/test'`)
   }
 })
 
@@ -137,6 +137,6 @@ test('Method already declared nested route', t => {
     findMyWay.on('GET', '/test/hello', () => {})
     t.fail('method already delcared in nested route')
   } catch (e) {
-    t.is(e.message, `Method 'GET' already declared for route 'hello'`)
+    t.is(e.message, `Method 'GET' already declared for route '/test/hello'`)
   }
 })


### PR DESCRIPTION
This changes the error message to include the full route path. This makes it easier to understand which route was declared twice.