### PR TITLE
Fix router.on() parameter validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,37 +40,35 @@ function Router (opts) {
 }
 
 Router.prototype.on = function on (method, path, handler, store) {
-  const register = (m, p, h, s) => {
-    if (!this.ignoreTrailingSlash || path === '/' || path.endsWith('*')) {
-      return this._on(m, p, h, s)
-    }
-    if (this.ignoreTrailingSlash && p.endsWith('/')) {
-      this._on(m, p, h, s)
-      this._on(m, p.slice(0, -1), h, s)
-      return
-    }
-    this._on(m, p, h, s)
-    this._on(m, p + '/', h, s)
-  }
-  if (Array.isArray(method)) {
-    for (var k = 0; k < method.length; k++) {
-      register(method[k], path, handler, store)
-    }
-    return
-  }
-  register(method, path, handler, store)
-}
-
-Router.prototype._on = function _on (method, path, handler, store) {
-  // method validation
-  assert(typeof method === 'string', 'Method should be a string')
-  assert(httpMethods.indexOf(method) !== -1, `Method '${method}' is not an http method.`)
   // path validation
   assert(typeof path === 'string', 'Path should be a string')
   assert(path.length > 0, 'The path could not be empty')
   assert(path[0] === '/' || path[0] === '*', 'The first character of a path should be `/` or `*`')
   // handler validation
   assert(typeof handler === 'function', 'Handler should be a function')
+
+  this._on(method, path, handler, store)
+
+  if (this.ignoreTrailingSlash && path !== '/' && !path.endsWith('*')) {
+    if (path.endsWith('/')) {
+      this._on(method, path.slice(0, -1), handler, store)
+    } else {
+      this._on(method, path + '/', handler, store)
+    }
+  }
+}
+
+Router.prototype._on = function _on (method, path, handler, store) {
+  if (Array.isArray(method)) {
+    for (var k = 0; k < method.length; k++) {
+      this._on(method[k], path, handler, store)
+    }
+    return
+  }
+
+  // method validation
+  assert(typeof method === 'string', 'Method should be a string')
+  assert(httpMethods.indexOf(method) !== -1, `Method '${method}' is not an http method.`)
 
   const params = []
   var j = 0

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -16,9 +16,33 @@ test('Method should be a string', t => {
   }
 })
 
+test('Method should be a string [ignoreTrailingSlash=true]', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
+
+  try {
+    findMyWay.on(0, '/test', () => {})
+    t.fail('method shoukd be a string')
+  } catch (e) {
+    t.is(e.message, 'Method should be a string')
+  }
+})
+
 test('Method should be a string (array)', t => {
   t.plan(1)
   const findMyWay = FindMyWay()
+
+  try {
+    findMyWay.on(['GET', 0], '/test', () => {})
+    t.fail('method shoukd be a string')
+  } catch (e) {
+    t.is(e.message, 'Method should be a string')
+  }
+})
+
+test('Method should be a string (array) [ignoreTrailingSlash=true]', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
 
   try {
     findMyWay.on(['GET', 0], '/test', () => {})
@@ -40,6 +64,18 @@ test('Path should be a string', t => {
   }
 })
 
+test('Path should be a string [ignoreTrailingSlash=true]', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
+
+  try {
+    findMyWay.on('GET', 0, () => {})
+    t.fail('path should be a string')
+  } catch (e) {
+    t.is(e.message, 'Path should be a string')
+  }
+})
+
 test('The path could not be empty', t => {
   t.plan(1)
   const findMyWay = FindMyWay()
@@ -52,9 +88,33 @@ test('The path could not be empty', t => {
   }
 })
 
+test('The path could not be empty [ignoreTrailingSlash=true]', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
+
+  try {
+    findMyWay.on('GET', '', () => {})
+    t.fail('The path could not be empty')
+  } catch (e) {
+    t.is(e.message, 'The path could not be empty')
+  }
+})
+
 test('The first character of a path should be `/` or `*`', t => {
   t.plan(1)
   const findMyWay = FindMyWay()
+
+  try {
+    findMyWay.on('GET', 'a', () => {})
+    t.fail('The first character of a path should be `/` or `*`')
+  } catch (e) {
+    t.is(e.message, 'The first character of a path should be `/` or `*`')
+  }
+})
+
+test('The first character of a path should be `/` or `*` [ignoreTrailingSlash=true]', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
 
   try {
     findMyWay.on('GET', 'a', () => {})
@@ -125,6 +185,52 @@ test('Method already declared', t => {
   }
 })
 
+test('Method already declared [ignoreTrailingSlash=true]', t => {
+  t.plan(2)
+
+  t.test('without trailing slash', t => {
+    t.plan(2)
+    const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
+
+    findMyWay.on('GET', '/test', () => {})
+
+    try {
+      findMyWay.on('GET', '/test', () => {})
+      t.fail('method already declared')
+    } catch (e) {
+      t.is(e.message, `Method 'GET' already declared for route '/test'`)
+    }
+
+    try {
+      findMyWay.on('GET', '/test/', () => {})
+      t.fail('method already declared')
+    } catch (e) {
+      t.is(e.message, `Method 'GET' already declared for route '/test/'`)
+    }
+  })
+
+  t.test('with trailing slash', t => {
+    t.plan(2)
+    const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
+
+    findMyWay.on('GET', '/test/', () => {})
+
+    try {
+      findMyWay.on('GET', '/test', () => {})
+      t.fail('method already declared')
+    } catch (e) {
+      t.is(e.message, `Method 'GET' already declared for route '/test'`)
+    }
+
+    try {
+      findMyWay.on('GET', '/test/', () => {})
+      t.fail('method already declared')
+    } catch (e) {
+      t.is(e.message, `Method 'GET' already declared for route '/test/'`)
+    }
+  })
+})
+
 test('Method already declared nested route', t => {
   t.plan(1)
   const findMyWay = FindMyWay()
@@ -139,4 +245,54 @@ test('Method already declared nested route', t => {
   } catch (e) {
     t.is(e.message, `Method 'GET' already declared for route '/test/hello'`)
   }
+})
+
+test('Method already declared nested route [ignoreTrailingSlash=true]', t => {
+  t.plan(2)
+
+  t.test('without trailing slash', t => {
+    t.plan(2)
+    const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
+
+    findMyWay.on('GET', '/test', () => {})
+    findMyWay.on('GET', '/test/hello', () => {})
+    findMyWay.on('GET', '/test/world', () => {})
+
+    try {
+      findMyWay.on('GET', '/test/hello', () => {})
+      t.fail('method already declared')
+    } catch (e) {
+      t.is(e.message, `Method 'GET' already declared for route '/test/hello'`)
+    }
+
+    try {
+      findMyWay.on('GET', '/test/hello/', () => {})
+      t.fail('method already declared')
+    } catch (e) {
+      t.is(e.message, `Method 'GET' already declared for route '/test/hello/'`)
+    }
+  })
+
+  t.test('with trailing slash', t => {
+    t.plan(2)
+    const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
+
+    findMyWay.on('GET', '/test/', () => {})
+    findMyWay.on('GET', '/test/hello/', () => {})
+    findMyWay.on('GET', '/test/world/', () => {})
+
+    try {
+      findMyWay.on('GET', '/test/hello', () => {})
+      t.fail('method already declared')
+    } catch (e) {
+      t.is(e.message, `Method 'GET' already declared for route '/test/hello'`)
+    }
+
+    try {
+      findMyWay.on('GET', '/test/hello/', () => {})
+      t.fail('method already declared')
+    } catch (e) {
+      t.is(e.message, `Method 'GET' already declared for route '/test/hello/'`)
+    }
+  })
 })


### PR DESCRIPTION
I noticed that one of the test cases in `errors.test.js` would fail when tested with `ignoreTrailingSlash=true`.

This adds a bunch of error tests for when `ignoreTrailingSlash` is `true` and fixes the `router.on()` code so that all the tests pass. This also speeds up validation a bit since the same parameters won't be validated multiple times when the input `method` is an array.