### PR TITLE
Invalid expressions for regexp parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,9 @@ Router.prototype._on = function _on (method, path, handler, store) {
         isRegex = isRegex || path[i] === '('
         if (isRegex) {
           i = path.indexOf(')', i) + 1
-          break
+          if (i) break
+
+          throw new TypeError("Invalid parameter regexp expression")
         } else if (path.charCodeAt(i) !== 45) {
           i++
         } else {

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ Router.prototype._on = function _on (method, path, handler, store) {
           i = path.indexOf(')', i) + 1
           if (i) break
 
-          throw new TypeError("Invalid parameter regexp expression")
+          throw new TypeError('Invalid parameter regexp expression')
         } else if (path.charCodeAt(i) !== 45) {
           i++
         } else {

--- a/index.js
+++ b/index.js
@@ -516,6 +516,12 @@ function getClosingParenthensePosition (path, idx) {
   while (idx < path.length) {
     idx++
 
+    // ignore skipped chars
+    if (path[idx] === '\\') {
+      idx++
+      continue
+    }
+
     if (path[idx] === ')') {
       parentheses--
     } else if (path[idx] === '(') {

--- a/index.js
+++ b/index.js
@@ -87,10 +87,8 @@ Router.prototype._on = function _on (method, path, handler, store) {
       while (i < len && path.charCodeAt(i) !== 47) {
         isRegex = isRegex || path[i] === '('
         if (isRegex) {
-          i = path.indexOf(')', i) + 1
-          if (i) break
-
-          throw new TypeError('Invalid parameter regexp expression')
+          i = getClosingParenthensePosition(path, i) + 1
+          break
         } else if (path.charCodeAt(i) !== 45) {
           i++
         } else {
@@ -497,4 +495,35 @@ function getWildcardNode (node, method, path, len) {
     }
   }
   return null
+}
+
+/**
+ * Returns the position of the last closing parenthese of the regexp expression.
+ *
+ * @param {String} path
+ * @param {Number} idx
+ * @returns {Number}
+ * @throws {TypeError} when a closing parenthese is missing
+ * @private
+ */
+function getClosingParenthensePosition (path, idx) {
+  // `path.indexOf()` will always return the first position of the closing parenthese,
+  // but it's inefficient for grouped or wrong regexp expressions.
+  // see issues #62 and #63 for more info
+
+  var parentheses = 1
+
+  while (idx < path.length) {
+    idx++
+
+    if (path[idx] === ')') {
+      parentheses--
+    } else if (path[idx] === '(') {
+      parentheses++
+    }
+
+    if (!parentheses) return idx
+  }
+
+  throw new TypeError('Invalid regexp expression in "' + path + '"')
 }

--- a/test/issue-62.test.js
+++ b/test/issue-62.test.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const t = require('tap')
+const factory = require('../')
+
+const noop = function () {}
+
+t.test('multi-character prefix', (t) => {
+  t.plan(2)
+
+  const fmw = factory()
+
+  fmw.on('GET', '/foo/:id(([a-f0-9]{3},?)+)', noop)
+
+  t.notOk(fmw.find('GET', '/foo/qwerty'), null)
+  t.ok(fmw.find('GET', '/foo/bac,1ea'))
+})

--- a/test/issue-62.test.js
+++ b/test/issue-62.test.js
@@ -5,13 +5,24 @@ const factory = require('../')
 
 const noop = function () {}
 
-t.test('multi-character prefix', (t) => {
+t.test('issue-62', (t) => {
   t.plan(2)
 
   const fmw = factory()
 
   fmw.on('GET', '/foo/:id(([a-f0-9]{3},?)+)', noop)
 
-  t.notOk(fmw.find('GET', '/foo/qwerty'), null)
+  t.notOk(fmw.find('GET', '/foo/qwerty'))
   t.ok(fmw.find('GET', '/foo/bac,1ea'))
+})
+
+t.test('issue-62 - escape chars', (t) => {
+  const fmw = factory()
+
+  t.plan(2)
+
+  fmw.get('/foo/:param(\\([a-f0-9]{3}\\))', noop)
+
+  t.notOk(fmw.find('GET', '/foo/abc'))
+  t.ok(fmw.find('GET', '/foo/(abc)'))
 })

--- a/test/issue-63.test.js
+++ b/test/issue-63.test.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const {test} = require('tap')
+const FindMyWay = require('../')
+const noop = () => {}
+
+test('issue-63', (t) => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  find.on('GET', '/foo/:id(a', noop)
+})

--- a/test/issue-63.test.js
+++ b/test/issue-63.test.js
@@ -3,12 +3,21 @@
 const t = require('tap')
 const factory = require('../')
 
+const noop = function () {}
+
 t.test('issue-63', (t) => {
-  t.plan(1)
+  t.plan(2)
 
   const fmw = factory()
 
   t.throws(function () {
-    fmw.on('GET', '/foo/:id(a', function () {})
+    fmw.on('GET', '/foo/:id(a', noop)
   })
+
+  try {
+    fmw.on('GET', '/foo/:id(a', noop)
+    t.fail('should fail')
+  } catch (err) {
+    t.is(err.message, 'Invalid regexp expression in "/foo/:id(a"')
+  }
 })

--- a/test/issue-63.test.js
+++ b/test/issue-63.test.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const {test} = require('tap')
-const FindMyWay = require('../')
-const noop = () => {}
+const t = require('tap')
+const factory = require('../')
 
-test('issue-63', (t) => {
+t.test('issue-63', (t) => {
   t.plan(1)
-  const findMyWay = FindMyWay()
+  const fmw = factory()
 
-  find.on('GET', '/foo/:id(a', noop)
+  fmw.on('GET', '/foo/:id(a', function () {})
 })

--- a/test/issue-63.test.js
+++ b/test/issue-63.test.js
@@ -5,7 +5,10 @@ const factory = require('../')
 
 t.test('issue-63', (t) => {
   t.plan(1)
+
   const fmw = factory()
 
-  fmw.on('GET', '/foo/:id(a', function () {})
+  t.throws(function () {
+    fmw.on('GET', '/foo/:id(a', function () {})
+  })
 })


### PR DESCRIPTION
Fixes #63 by throwing a `TypeError` error if the regexp expressions is wrong
Fixes #62 