### PR TITLE
Fix issue looking up routes that don't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -300,7 +300,7 @@ Router.prototype.find = function find (method, path) {
     i = pathLen < prefixLen ? pathLen : prefixLen
     while (len < i && path[len] === prefix[len]) len++
 
-    if (len === prefixLen) {
+    if (len > 0) {
       path = path.slice(len)
       pathLen = path.length
     }

--- a/index.js
+++ b/index.js
@@ -267,6 +267,7 @@ Router.prototype.find = function find (method, path) {
   var pindex = 0
   var params = []
   var i = 0
+  var isStatic = true
 
   while (true) {
     var pathLen = path.length
@@ -300,7 +301,7 @@ Router.prototype.find = function find (method, path) {
     i = pathLen < prefixLen ? pathLen : prefixLen
     while (len < i && path[len] === prefix[len]) len++
 
-    if (len > 0) {
+    if ((isStatic === true && len > 0) || len === prefixLen) {
       path = path.slice(len)
       pathLen = path.length
     }
@@ -331,6 +332,8 @@ Router.prototype.find = function find (method, path) {
     if (len !== prefixLen) {
       return getWildcardNode(wildcardNode, method, originalPath, pathLenWildcard)
     }
+
+    isStatic = false
 
     // if exist, save the wildcard child
     if (currentNode.wildcardChild !== null) {

--- a/test/issue-59.test.js
+++ b/test/issue-59.test.js
@@ -25,7 +25,80 @@ test('multi-character prefix', t => {
   t.equal(findMyWay.find('GET', '/bulk'), null)
 })
 
-test('with parameter', t => {
+test('static / 1', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/bb/', noop)
+  findMyWay.on('GET', '/bb/bulk', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+})
+
+test('static / 2', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/bb/ff/', noop)
+  findMyWay.on('GET', '/bb/ff/bulk', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+  t.equal(findMyWay.find('GET', '/ff/bulk'), null)
+})
+
+test('static / 3', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/bb/ff/', noop)
+  findMyWay.on('GET', '/bb/ff/bulk', noop)
+  findMyWay.on('GET', '/bb/ff/gg/bulk', noop)
+  findMyWay.on('GET', '/bb/ff/bulk/bulk', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+})
+
+test('with parameter / 1', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/:foo/', noop)
+  findMyWay.on('GET', '/:foo/bulk', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+})
+
+test('with parameter / 2', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/bb/', noop)
+  findMyWay.on('GET', '/bb/:foo', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+})
+
+test('with parameter / 3', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/bb/ff/', noop)
+  findMyWay.on('GET', '/bb/ff/:foo', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+})
+
+test('with parameter / 4', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/bb/:foo/', noop)
+  findMyWay.on('GET', '/bb/:foo/bulk', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+})
+
+test('with parameter / 5', t => {
   t.plan(2)
   const findMyWay = FindMyWay()
 
@@ -34,4 +107,26 @@ test('with parameter', t => {
 
   t.equal(findMyWay.find('GET', '/bulk'), null)
   t.equal(findMyWay.find('GET', '/bb/foo/bulk'), null)
+})
+
+test('with parameter / 6', t => {
+  t.plan(3)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/static/:parametric/static/:parametric', noop)
+  findMyWay.on('GET', '/static/:parametric/static/:parametric/bulk', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+  t.equal(findMyWay.find('GET', '/static/foo/bulk'), null)
+  t.notEqual(findMyWay.find('GET', '/static/foo/static/bulk'), null)
+})
+
+test('wildcard / 1', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/bb/', noop)
+  findMyWay.on('GET', '/bb/*', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
 })

--- a/test/issue-59.test.js
+++ b/test/issue-59.test.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+const noop = () => {}
+
+test('single-character prefix', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/b/', noop)
+  findMyWay.on('GET', '/b/bulk', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+})
+
+test('multi-character prefix', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/bu/', noop)
+  findMyWay.on('GET', '/bu/bulk', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+})

--- a/test/issue-59.test.js
+++ b/test/issue-59.test.js
@@ -24,3 +24,14 @@ test('multi-character prefix', t => {
 
   t.equal(findMyWay.find('GET', '/bulk'), null)
 })
+
+test('with parameter', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/bb/:foo/aa/', noop)
+  findMyWay.on('GET', '/bb/:foo/aa/bulk', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+  t.equal(findMyWay.find('GET', '/bb/foo/bulk'), null)
+})


### PR DESCRIPTION
How this fix works:

When matching a path to a prefix in a `node`, this part of the code finds the longest common prefix. Before it would only look for the next part of the path if the path matched the entire prefix, otherwise it would continue matching the same path. This was wrong because then this would happen:

```
path = 'bulk'
prefix = 'b/'
commonPrefix = 'b'
-- does not update path --
finds child with prefix = 'bulk'
goes back to the top and matches 'bulk'
return handler for '/b/bulk'
```

With this fix it does this:

```
path = 'bulk'
prefix = 'b/'
commonPrefix = 'b'
update path = 'ulk'
no children match 'ulk'
return null
```

<details>
<summary>benchmarks</summary>

**before**
```
lookup static route x 26,167,641 ops/sec ±1.42% (89 runs sampled)
lookup dynamic route x 1,568,707 ops/sec ±0.56% (93 runs sampled)
lookup dynamic multi-parametric route x 872,150 ops/sec ±1.18% (90 runs sampled)
lookup dynamic multi-parametric route with regex x 800,702 ops/sec ±1.98% (83 runs sampled)
lookup long static route x 2,584,658 ops/sec ±1.07% (92 runs sampled)
find static route x 32,397,375 ops/sec ±1.69% (89 runs sampled)
find dynamic route x 1,942,803 ops/sec ±1.57% (88 runs sampled)
find dynamic multi-parametric route x 1,066,697 ops/sec ±1.29% (88 runs sampled)
find dynamic multi-parametric route with regex x 926,740 ops/sec ±1.48% (90 runs sampled)
find long static route x 4,905,622 ops/sec ±1.39% (89 runs sampled)
```

**after**
```
lookup static route x 27,301,612 ops/sec ±1.26% (88 runs sampled)
lookup dynamic route x 1,576,759 ops/sec ±0.55% (94 runs sampled)
lookup dynamic multi-parametric route x 890,252 ops/sec ±0.56% (94 runs sampled)
lookup dynamic multi-parametric route with regex x 845,854 ops/sec ±0.43% (93 runs sampled)
lookup long static route x 2,425,642 ops/sec ±0.64% (93 runs sampled)
find static route x 30,674,123 ops/sec ±0.81% (88 runs sampled)
find dynamic route x 1,875,931 ops/sec ±0.76% (93 runs sampled)
find dynamic multi-parametric route x 1,037,566 ops/sec ±0.63% (92 runs sampled)
find dynamic multi-parametric route with regex x 955,495 ops/sec ±0.90% (94 runs sampled)
find long static route x 4,807,380 ops/sec ±0.67% (94 runs sampled)
```
</details>
<br>

Alternative to #61.

Fixes #59
Fixes #60