### PR TITLE
Fix route matching issue with common prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,7 +275,6 @@ Router.prototype.find = function find (method, path) {
   var pindex = 0
   var params = []
   var i = 0
-  var isStatic = true
 
   while (true) {
     var pathLen = path.length
@@ -309,12 +308,12 @@ Router.prototype.find = function find (method, path) {
     i = pathLen < prefixLen ? pathLen : prefixLen
     while (len < i && path[len] === prefix[len]) len++
 
-    if ((isStatic === true && len > 0) || len === prefixLen) {
+    if (len === prefixLen) {
       path = path.slice(len)
       pathLen = path.length
     }
 
-    var node = currentNode.find(path[0], method)
+    var node = currentNode.find(path, method)
     if (node === null) {
       node = currentNode.parametricBrother
       if (node === null) {
@@ -340,8 +339,6 @@ Router.prototype.find = function find (method, path) {
     if (len !== prefixLen) {
       return getWildcardNode(wildcardNode, method, originalPath, pathLenWildcard)
     }
-
-    isStatic = false
 
     // if exist, save the wildcard child
     if (currentNode.wildcardChild !== null) {

--- a/node.js
+++ b/node.js
@@ -67,7 +67,7 @@ Node.prototype.find = function (path, method) {
     var child = this.children[i]
     if (
       (child.numberOfChildren !== 0 || child.handlers[method] !== null) &&
-      (child.kind !== 0 || path.startsWith(child.prefix))
+      (child.kind !== 0 || path.slice(0, child.prefix.length) === child.prefix)
     ) {
       return child
     }

--- a/node.js
+++ b/node.js
@@ -62,14 +62,14 @@ Node.prototype.findByLabel = function (label) {
   return null
 }
 
-Node.prototype.find = function (label, method) {
+Node.prototype.find = function (path, method) {
   for (var i = 0; i < this.numberOfChildren; i++) {
     var child = this.children[i]
-    if (child.numberOfChildren !== 0 || child.handlers[method] !== null) {
-      if (child.label === label && child.kind === 0) {
-        return child
-      }
-      if (child.kind !== 0) return child
+    if (
+      (child.numberOfChildren !== 0 || child.handlers[method] !== null) &&
+      (child.kind !== 0 || path.startsWith(child.prefix))
+    ) {
+      return child
     }
   }
   return null

--- a/test/issue-67.test.js
+++ b/test/issue-67.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+const noop = () => {}
+
+test('static routes', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/b/', noop)
+  findMyWay.on('GET', '/b/bulk', noop)
+  findMyWay.on('GET', '/b/ulk', noop)
+
+  t.equal(findMyWay.find('GET', '/bulk'), null)
+})
+
+test('parametric routes', t => {
+  t.plan(5)
+  const findMyWay = FindMyWay()
+
+  function foo () { }
+
+  findMyWay.on('GET', '/foo/:fooParam', foo)
+  findMyWay.on('GET', '/foo/bar/:barParam', noop)
+  findMyWay.on('GET', '/foo/search', noop)
+  findMyWay.on('GET', '/foo/submit', noop)
+
+  t.equal(findMyWay.find('GET', '/foo/awesome-parameter').handler, foo)
+  t.equal(findMyWay.find('GET', '/foo/b-first-character').handler, foo)
+  t.equal(findMyWay.find('GET', '/foo/s-first-character').handler, foo)
+  t.equal(findMyWay.find('GET', '/foo/se-prefix').handler, foo)
+  t.equal(findMyWay.find('GET', '/foo/sx-prefix').handler, foo)
+})


### PR DESCRIPTION
The `Node#find()` method was trying to take a shortcut by matching against the node's "label" (the first character of the prefix). This fixes route matching issues by matching against the entire prefix when the node is a static node.

Fixes #67
This is the correct fix for #59/#60

<details>
<summary>Benchmark</summary>

**before**
```
lookup static route x 29,941,458 ops/sec ±2.24% (90 runs sampled)
lookup dynamic route x 1,707,649 ops/sec ±1.97% (94 runs sampled)
lookup dynamic multi-parametric route x 974,717 ops/sec ±0.43% (94 runs sampled)
lookup dynamic multi-parametric route with regex x 889,377 ops/sec ±0.52% (96 runs sampled)
lookup long static route x 2,713,562 ops/sec ±0.42% (94 runs sampled)
find static route x 35,555,376 ops/sec ±0.81% (96 runs sampled)
find dynamic route x 2,027,441 ops/sec ±0.51% (93 runs sampled)
find dynamic multi-parametric route x 1,153,594 ops/sec ±0.32% (98 runs sampled)
find dynamic multi-parametric route with regex x 1,000,319 ops/sec ±0.51% (96 runs sampled)
find long static route x 5,245,622 ops/sec ±0.36% (95 runs sampled)
```

**after**
```
lookup static route x 32,129,986 ops/sec ±0.80% (88 runs sampled)
lookup dynamic route x 1,672,248 ops/sec ±0.45% (97 runs sampled)
lookup dynamic multi-parametric route x 930,559 ops/sec ±0.40% (92 runs sampled)
lookup dynamic multi-parametric route with regex x 840,688 ops/sec ±0.43% (97 runs sampled)
lookup long static route x 2,019,996 ops/sec ±0.40% (98 runs sampled)
find static route x 36,189,618 ops/sec ±0.71% (94 runs sampled)
find dynamic route x 2,049,103 ops/sec ±0.51% (93 runs sampled)
find dynamic multi-parametric route x 1,088,319 ops/sec ±0.64% (95 runs sampled)
find dynamic multi-parametric route with regex x 946,871 ops/sec ±0.60% (92 runs sampled)
find long static route x 3,108,926 ops/sec ±0.39% (98 runs sampled)
```
<!-- OLD BENCHMARK
```
lookup static route x 31,609,640 ops/sec ±0.70% (87 runs sampled)
lookup dynamic route x 1,631,370 ops/sec ±0.31% (95 runs sampled)
lookup dynamic multi-parametric route x 876,612 ops/sec ±0.59% (89 runs sampled)
lookup dynamic multi-parametric route with regex x 753,410 ops/sec ±0.37% (96 runs sampled)
lookup long static route x 1,608,347 ops/sec ±0.44% (95 runs sampled)
find static route x 36,568,772 ops/sec ±0.59% (91 runs sampled)
find dynamic route x 1,879,548 ops/sec ±0.66% (95 runs sampled)
find dynamic multi-parametric route x 1,002,888 ops/sec ±0.37% (93 runs sampled)
find dynamic multi-parametric route with regex x 813,702 ops/sec ±0.64% (94 runs sampled)
find long static route x 2,359,763 ops/sec ±0.31% (98 runs sampled)
```
-->
</details>

Benchmarks drop the longer the route is. This may be because now there's some duplicated prefix matching somewhere.