### PR TITLE
Fix lookups of unsupported methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ Router.prototype.find = function find (method, path) {
     // found the route
     if (pathLen === 0 || path === prefix) {
       var handle = currentNode.handlers[method]
-      if (handle !== null) {
+      if (handle !== null && handle !== undefined) {
         var paramsObj = {}
         if (handle.paramsLength > 0) {
           var paramNames = handle.params
@@ -455,7 +455,7 @@ function getWildcardNode (node, method, path, len) {
   var decoded = fastDecode(path.slice(-len))
   if (decoded === null) return null
   var handle = node.handlers[method]
-  if (handle !== null) {
+  if (handle !== null && handle !== undefined) {
     return {
       handler: handle.handler,
       params: { '*': decoded },

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -676,7 +676,7 @@ test('Unsupported method (static)', t => {
     t.fail('We should not be here')
   })
 
-  findMyWay.lookup({ method: 'PROPFIND', url: '/' }, null)
+  findMyWay.lookup({ method: 'TROLL', url: '/' }, null)
 })
 
 test('Unsupported method (wildcard)', t => {
@@ -691,7 +691,7 @@ test('Unsupported method (wildcard)', t => {
     t.fail('We should not be here')
   })
 
-  findMyWay.lookup({ method: 'PROPFIND', url: '/hello/world' }, null)
+  findMyWay.lookup({ method: 'TROLL', url: '/hello/world' }, null)
 })
 
 test('Unsupported method (static find)', t => {
@@ -700,7 +700,7 @@ test('Unsupported method (static find)', t => {
 
   findMyWay.on('GET', '/', () => {})
 
-  t.deepEqual(findMyWay.find('PROPFIND', '/'), null)
+  t.deepEqual(findMyWay.find('TROLL', '/'), null)
 })
 
 test('Unsupported method (wildcard find)', t => {
@@ -709,7 +709,7 @@ test('Unsupported method (wildcard find)', t => {
 
   findMyWay.on('GET', '*', () => {})
 
-  t.deepEqual(findMyWay.find('PROPFIND', '/hello/world'), null)
+  t.deepEqual(findMyWay.find('TROLL', '/hello/world'), null)
 })
 
 test('register all known HTTP methods', t => {


### PR DESCRIPTION
Currently, looking up an unsupported is throwing an error because the method isn't in the `handlers` object, so trying to get a handler from the `handlers` object will return `undefined` (and currently only `null` is being handled).