### PR TITLE
Safe regex by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "9"
+  - "10"
   - "8"
   - "6"
   - "4"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ const router = require('find-my-way')({
   maxParamLength: 500
 })
 ```
+
+If you are using a regex based route, `find-my-way` will throw an error if detects potentially catastrophic exponential-time regular expressions *(internally uses [`safe-regex`](https://github.com/substack/safe-regex))*.<br/>
+If you want to disable this behavior, pass the option `allowUnsafeRegex`.
+```js
+const router = require('find-my-way')({
+  allowUnsafeRegex: true
+})
+```
 <a name="on"></a>
 #### on(method, path, handler, [store])
 Register a new route.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "tap": "^11.0.0"
   },
   "dependencies": {
-    "fast-decode-uri-component": "^1.0.0"
+    "fast-decode-uri-component": "^1.0.0",
+    "safe-regex": "^1.1.0"
   }
 }

--- a/test/issue-62.test.js
+++ b/test/issue-62.test.js
@@ -1,28 +1,28 @@
 'use strict'
 
 const t = require('tap')
-const factory = require('../')
+const FindMyWay = require('../')
 
 const noop = function () {}
 
 t.test('issue-62', (t) => {
   t.plan(2)
 
-  const fmw = factory()
+  const findMyWay = FindMyWay({ allowUnsafeRegex: true })
 
-  fmw.on('GET', '/foo/:id(([a-f0-9]{3},?)+)', noop)
+  findMyWay.on('GET', '/foo/:id(([a-f0-9]{3},?)+)', noop)
 
-  t.notOk(fmw.find('GET', '/foo/qwerty'))
-  t.ok(fmw.find('GET', '/foo/bac,1ea'))
+  t.notOk(findMyWay.find('GET', '/foo/qwerty'))
+  t.ok(findMyWay.find('GET', '/foo/bac,1ea'))
 })
 
 t.test('issue-62 - escape chars', (t) => {
-  const fmw = factory()
+  const findMyWay = FindMyWay()
 
   t.plan(2)
 
-  fmw.get('/foo/:param(\\([a-f0-9]{3}\\))', noop)
+  findMyWay.get('/foo/:param(\\([a-f0-9]{3}\\))', noop)
 
-  t.notOk(fmw.find('GET', '/foo/abc'))
-  t.ok(fmw.find('GET', '/foo/(abc)'))
+  t.notOk(findMyWay.find('GET', '/foo/abc'))
+  t.ok(findMyWay.find('GET', '/foo/(abc)'))
 })

--- a/test/regex.test.js
+++ b/test/regex.test.js
@@ -143,3 +143,98 @@ test('safe decodeURIComponent', t => {
     null
   )
 })
+
+test('Should check if a regex is safe to use', t => {
+  t.plan(13)
+
+  const noop = () => {}
+
+  // https://github.com/substack/safe-regex/blob/master/test/regex.js
+  const good = [
+    /\bOakland\b/,
+    /\b(Oakland|San Francisco)\b/i,
+    /^\d+1337\d+$/i,
+    /^\d+(1337|404)\d+$/i,
+    /^\d+(1337|404)*\d+$/i,
+    RegExp(Array(26).join('a?') + Array(26).join('a'))
+  ]
+
+  const bad = [
+    /^(a?){25}(a){25}$/,
+    RegExp(Array(27).join('a?') + Array(27).join('a')),
+    /(x+x+)+y/,
+    /foo|(x+x+)+y/,
+    /(a+){10}y/,
+    /(a+){2}y/,
+    /(.*){1,32000}[bc]/
+  ]
+
+  const findMyWay = FindMyWay()
+
+  good.forEach(regex => {
+    try {
+      findMyWay.on('GET', `/test/:id(${regex.toString()})`, noop)
+      t.pass('ok')
+      findMyWay.off('GET', `/test/:id(${regex.toString()})`, noop)
+    } catch (err) {
+      t.fail(err)
+    }
+  })
+
+  bad.forEach(regex => {
+    try {
+      findMyWay.on('GET', `/test/:id(${regex.toString()})`, noop)
+      t.fail('should throw')
+    } catch (err) {
+      t.ok(err)
+    }
+  })
+})
+
+test('Disable safe regex check', t => {
+  t.plan(13)
+
+  const noop = () => {}
+
+  // https://github.com/substack/safe-regex/blob/master/test/regex.js
+  const good = [
+    /\bOakland\b/,
+    /\b(Oakland|San Francisco)\b/i,
+    /^\d+1337\d+$/i,
+    /^\d+(1337|404)\d+$/i,
+    /^\d+(1337|404)*\d+$/i,
+    RegExp(Array(26).join('a?') + Array(26).join('a'))
+  ]
+
+  const bad = [
+    /^(a?){25}(a){25}$/,
+    RegExp(Array(27).join('a?') + Array(27).join('a')),
+    /(x+x+)+y/,
+    /foo|(x+x+)+y/,
+    /(a+){10}y/,
+    /(a+){2}y/,
+    /(.*){1,32000}[bc]/
+  ]
+
+  const findMyWay = FindMyWay({ allowUnsafeRegex: true })
+
+  good.forEach(regex => {
+    try {
+      findMyWay.on('GET', `/test/:id(${regex.toString()})`, noop)
+      t.pass('ok')
+      findMyWay.off('GET', `/test/:id(${regex.toString()})`, noop)
+    } catch (err) {
+      t.fail(err)
+    }
+  })
+
+  bad.forEach(regex => {
+    try {
+      findMyWay.on('GET', `/test/:id(${regex.toString()})`, noop)
+      t.pass('ok')
+      findMyWay.off('GET', `/test/:id(${regex.toString()})`, noop)
+    } catch (err) {
+      t.fail(err)
+    }
+  })
+})


### PR DESCRIPTION
Now `find-my-way` detects potentially catastrophic exponential-time regular expressions thanks to [`safe-regex`](https://github.com/substack/safe-regex).

This check can be disabled with `{ allowUnsafeRegex: true }`.

cc @hekike