### PR TITLE
prevent looping over prototype chain

### DIFF
--- a/node.js
+++ b/node.js
@@ -214,7 +214,7 @@ Node.prototype.prettyPrint = function (prefix, tail) {
 function buildHandlers (handlers) {
   var code = `handlers = handlers || {}
   `
-  for (var i in http.METHODS) {
+  for (var i = 0; i < http.METHODS.length; i++) {
     var m = http.METHODS[i]
     code += `this['${m}'] = handlers['${m}'] || null
     `


### PR DESCRIPTION
Some libraries add function to (Iteratable) Array.prototype and for(var .. in ..) loop will iterate over those function and code will throw syntax error if the function clousure has more than one line.