### PR TITLE
Use generated radix tree

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -12,7 +12,7 @@ findMyWay.on('GET', '/user/:id/static', () => true)
 findMyWay.on('GET', '/customer/:name-:surname', () => true)
 findMyWay.on('GET', '/at/:hour(^\\d+)h:minute(^\\d+)m', () => true)
 findMyWay.on('GET', '/abc/def/ghi/lmn/opq/rst/uvz', () => true)
-findMyWay.on('GET', '/', { version: '1.2.0' }, () => true)
+// findMyWay.on('GET', '/', { version: '1.2.0' }, () => true)
 
 suite
   .add('lookup static route', function () {
@@ -33,9 +33,9 @@ suite
   .add('lookup long dynamic route', function () {
     findMyWay.lookup({ method: 'GET', url: '/user/qwertyuiopasdfghjklzxcvbnm/static', headers: {} }, null)
   })
-  .add('lookup static versioned route', function () {
-    findMyWay.lookup({ method: 'GET', url: '/', headers: { 'accept-version': '1.x' } }, null)
-  })
+//  .add('lookup static versioned route', function () {
+//    findMyWay.lookup({ method: 'GET', url: '/', headers: { 'accept-version': '1.x' } }, null)
+//  })
   .add('find static route', function () {
     findMyWay.find('GET', '/', undefined)
   })
@@ -54,9 +54,9 @@ suite
   .add('find long dynamic route', function () {
     findMyWay.find('GET', '/user/qwertyuiopasdfghjklzxcvbnm/static', undefined)
   })
-  .add('find static versioned route', function () {
-    findMyWay.find('GET', '/', '1.x')
-  })
+//  .add('find static versioned route', function () {
+//    findMyWay.find('GET', '/', '1.x')
+//  })
   .on('cycle', function (event) {
     console.log(String(event.target))
   })

--- a/generate.js
+++ b/generate.js
@@ -1,0 +1,183 @@
+const gentree = require('generate-radix-tree')
+const genfun = require('generate-function')
+
+module.exports = genrouter
+
+function genrouter (routes) {
+  const group = {}
+  const cache = {}
+
+  for (var i = 0; i < routes.length; i++) {
+    const m = routes[i].method
+    const g = group[m] = group[m] || { match: m, routes: [] }
+    g.routes.push({
+      match: compile(routes[i].path),
+      handler: routes[i].handler,
+      store: routes[i].store
+    })
+  }
+
+  const input = Object.keys(group).map(key => group[key])
+  const gen = genfun()
+
+  gen('function route (method, path) {')
+
+  gentree(input, {
+    name: 'method',
+    gen,
+    onvalue (gen, method) {
+      gentree(method.routes, {
+        name: 'path',
+        gen,
+        onvalue (gen, route) {
+          const idx = gen.sym(method.match) + method.routes.indexOf(route)
+          gen.scope[idx] = route
+          if (typeof route.match === 'string') {
+            gen(`return {
+              handler: ${idx}.handler,
+              store: ${idx}.store,
+              params: {}
+            }`)
+          } else {
+            gen(`return {
+              handler: ${idx}.handler,
+              store: ${idx}.store,
+              params: {
+            `)
+            const params = route.match.filter(m => typeof m === 'function')
+            for (var i = 0; i < params.length; i++) {
+              const n = name(params[i])
+              const sep = i < params.length - 1 ? ',' : ''
+              gen(`${gen.property(params[i].sym)}: ${n}.value${sep}`)
+            }
+            gen('}')
+            gen('}')
+          }
+        }
+      })
+    }
+  })
+
+  gen('return null')
+  gen('}')
+
+  return gen.toFunction()
+
+  function name (fun) {
+    for (const key of Object.keys(gen.scope)) {
+      if (gen.scope[key] === fun) return key
+    }
+    return null
+  }
+
+  function compileFunction (pattern, i, all) {
+    const next = (i < all.length - 1 && !/^[:*]/.test(all[i + 1]))
+      ? all[i + 1][0]
+      : ''
+
+    const id = next + '@' + pattern
+
+    if (cache[id]) return cache[id]
+
+    if (pattern[0] === ':') {
+      const regex = pattern.indexOf('(')
+      const gen = genfun()
+      gen.scope.duc = require('fast-decode-uri-component')
+      gen('function match (s, ptr) {')
+      if (regex > -1) {
+        gen(`
+          const m = s.slice(ptr).match(/^${pattern.slice(regex + 1, -1)}/g)
+          if (!m) return false
+          if ((match.value = duc(m[0])) === null) return false
+          match.pointer = ptr + match.value.length
+          return true
+        `)
+      } else if (next) {
+        gen(`
+          const i = s.indexOf(${JSON.stringify(next)}, ptr)
+          if (i === -1) return false
+          if ((match.value = duc(s.slice(ptr, i))) === null) return false
+        `)
+        if (next !== '/') {
+          gen('if (match.value.indexOf("/") > -1) return false')
+        }
+        gen(`
+          match.pointer = i
+          return true
+        `)
+      } else {
+        gen(`
+          const i = s.indexOf("/", ptr)
+          if (i > -1) return false
+          if ((match.value = duc(s.slice(ptr))) === null) return false
+          match.pointer = s.length
+          return true
+        `)
+      }
+      const fn = cache[id] = gen('}').toFunction()
+      fn.pointer = 0
+      fn.value = ''
+      fn.sym = pattern.slice(1, regex === -1 ? pattern.length : regex)
+      return fn
+    }
+
+    if (pattern[0] === '*') {
+      const gen = genfun()
+      gen.scope.duc = require('fast-decode-uri-component')
+      gen('function wildcard (s, ptr) {')
+      if (next) {
+        gen(`
+          const i = s.indexOf(${JSON.stringify(next)}, ptr)
+          if (i === -1) return false
+          if ((wildcard.value = duc(s.slice(ptr, i))) === null) return false
+          wildcard.pointer = i
+          return true
+        `)
+      } else {
+        gen(`
+          if ((wildcard.value = duc(s.slice(ptr))) === null) return false
+          wildcard.pointer = s.length
+          return true
+        `)
+      }
+      const fn = cache[id] = gen('}').toFunction()
+      fn.pointer = 0
+      fn.value = ''
+      fn.sym = '*'
+      return fn
+    }
+
+    return pattern
+  }
+
+  function compile (pattern) {
+    const res = []
+    var offset = 0
+    for (var i = 0; i < pattern.length; i++) {
+      if (pattern[i] === '*') {
+        res.push(pattern.slice(offset, i))
+        res.push('*')
+        offset = i + 1
+        continue
+      }
+      if (pattern[i] === ':') {
+        var inc = 0
+        res.push(pattern.slice(offset, i))
+        offset = i++
+        for (; i < pattern.length; i++) {
+          if (pattern[i] === '(') inc++
+          else if (inc && pattern[i] === ')') inc--
+          else if (!inc && (!/[$_a-z0-9]/i.test(pattern[i]) || pattern[i - 1] === ')')) break
+        }
+        if (inc) throw new Error('Invalid regexp expression in "' + pattern + '"')
+        res.push(pattern.slice(offset, i))
+        offset = i
+        continue
+      }
+    }
+
+    if (!res.length) return pattern
+    if (offset < pattern.length) res.push(pattern.slice(offset))
+    return res.map(compileFunction)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "fast-decode-uri-component": "^1.0.0",
+    "generate-radix-tree": "^1.0.2",
     "safe-regex": "^1.1.0",
     "semver-store": "^0.3.0"
   }


### PR DESCRIPTION
This makes the router use a code generated radix tree instead.
Main things missing:

* [ ] Add missing options (such as case insensitive etc, shouldn't be hard at all)
* [ ] Fix regex issue. I'm not sure how your regex matcher works. I just do an eager match against the pattern passed, but you support `$` as an inplace regex which I'm unsure what means
* [ ] Remove dead code. We can prob remove 75% of the code :D
* [ ] Versioned routes. Unsure how these work.
* [ ] Don't compile on each .on, but do it nextTick or something?

Benchmarks

## Before

```
lookup static route x 56,675,717 ops/sec ±3.91% (92 runs sampled)
lookup dynamic route x 3,907,986 ops/sec ±1.61% (92 runs sampled)
lookup dynamic multi-parametric route x 2,094,830 ops/sec ±1.50% (94 runs sampled)
lookup dynamic multi-parametric route with regex x 1,559,524 ops/sec ±0.91% (97 runs sampled)
lookup long static route x 3,840,774 ops/sec ±0.72% (94 runs sampled)
lookup long dynamic route x 2,517,142 ops/sec ±0.56% (95 runs sampled)
find static route x 46,681,402 ops/sec ±0.79% (97 runs sampled)
find dynamic route x 4,471,999 ops/sec ±1.18% (90 runs sampled)
find dynamic multi-parametric route x 2,275,319 ops/sec ±1.89% (91 runs sampled)
find dynamic multi-parametric route with regex x 1,636,727 ops/sec ±1.38% (92 runs sampled)
find long static route x 5,429,251 ops/sec ±0.88% (92 runs sampled)
find long dynamic route x 3,462,368 ops/sec ±0.73% (90 runs sampled)
```

## After

```
lookup static route x 52,844,596 ops/sec ±0.64% (91 runs sampled)
lookup dynamic route x 9,299,696 ops/sec ±1.13% (91 runs sampled)
lookup dynamic multi-parametric route x 5,123,525 ops/sec ±1.20% (92 runs sampled)
lookup dynamic multi-parametric route with regex x 2,952,715 ops/sec ±0.91% (92 runs sampled)
lookup long static route x 7,437,460 ops/sec ±1.05% (95 runs sampled)
lookup long dynamic route x 5,207,066 ops/sec ±0.87% (97 runs sampled)
find static route x 72,317,353 ops/sec ±0.88% (96 runs sampled)
find dynamic route x 14,775,400 ops/sec ±1.96% (91 runs sampled)
find dynamic multi-parametric route x 6,813,272 ops/sec ±0.91% (92 runs sampled)
find dynamic multi-parametric route with regex x 3,257,229 ops/sec ±1.11% (93 runs sampled)
find long static route x 14,222,061 ops/sec ±3.74% (88 runs sampled)
find long dynamic route x 10,972,760 ops/sec ±0.62% (93 runs sampled)
```

(Missing versioned routes as it's not impl yet, but most of these are >2x faster :))