### PR TITLE
fix: Fix `versions` parameter not work in Node constructor

### DIFF
--- a/node.js
+++ b/node.js
@@ -24,7 +24,7 @@ function Node (prefix, children, kind, handlers, regex, versions) {
   this.regex = regex || null
   this.wildcardChild = null
   this.parametricBrother = null
-  this.versions = SemVerStore()
+  this.versions = versions || SemVerStore()
 }
 
 Object.defineProperty(Node.prototype, 'types', {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "benchmark": "^2.1.4",
     "coveralls": "^3.0.2",
     "pre-commit": "^1.2.2",
-    "request": "^2.87.0",
-    "standard": "^11.0.1",
+    "request": "^2.88.0",
+    "standard": "^12.0.1",
     "tap": "^12.0.1"
   },
   "dependencies": {

--- a/test/issue-93.test.js
+++ b/test/issue-93.test.js
@@ -6,12 +6,15 @@ const FindMyWay = require('../')
 const noop = () => {}
 
 test('Should keep semver store when split node', t => {
-  t.plan(1)
+  t.plan(4)
 
   const findMyWay = FindMyWay()
 
-  findMyWay.on('GET', '/t1', { version: '0.1.0' }, noop)
-  findMyWay.on('GET', '/t2', { version: '0.1.0' }, noop)
+  findMyWay.on('GET', '/t1', { version: '1.0.0' }, noop)
+  findMyWay.on('GET', '/t2', { version: '2.1.0' }, noop)
 
-  t.ok(findMyWay.find('GET', '/t1', '0.1.0'))
+  t.ok(findMyWay.find('GET', '/t1', '1.0.0'))
+  t.ok(findMyWay.find('GET', '/t2', '2.x'))
+  t.notOk(findMyWay.find('GET', '/t1', '2.x'))
+  t.notOk(findMyWay.find('GET', '/t2', '1.0.0'))
 })

--- a/test/issue-93.test.js
+++ b/test/issue-93.test.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+const noop = () => {}
+
+test('Should keep semver store when split node', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/t1', { version: '0.1.0' }, noop)
+  findMyWay.on('GET', '/t2', { version: '0.1.0' }, noop)
+
+  t.ok(findMyWay.find('GET', '/t1', '0.1.0'))
+})


### PR DESCRIPTION
- Fix issue 93
- Add a test case for that
- Update dependencies by the way (no break change)