### PR TITLE
Falling back to node's parametricBrother

### DIFF
--- a/node.js
+++ b/node.js
@@ -84,7 +84,7 @@ Node.prototype.addChild = function (node) {
     }
 
     if (node !== this) {
-      node.parametricBrother = parametricBrother
+      node.parametricBrother = parametricBrother || node.parametricBrother
     }
 
     const labels = Object.keys(node.children)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pre-commit": "^1.2.2",
     "request": "^2.88.0",
     "standard": "^12.0.1",
-    "tap": "^12.0.1",
+    "tap": "12.4.1",
     "typescript": "^3.2.1"
   },
   "dependencies": {

--- a/test/issue-110.test.js
+++ b/test/issue-110.test.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+
+test('Nested static parametric route, url with parameter common prefix > 1', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/api/foo/b2', (req, res) => {
+    res.end('{"message":"hello world"}')
+  })
+
+  findMyWay.on('GET', '/api/foo/bar/qux', (req, res) => {
+    res.end('{"message":"hello world"}')
+  })
+
+  findMyWay.on('GET', '/api/foo/:id/bar', (req, res) => {
+    res.end('{"message":"hello world"}')
+  })
+
+  findMyWay.on('GET', '/foo', (req, res) => {
+    res.end('{"message":"hello world"}')
+  })
+
+  t.deepEqual(findMyWay.find('GET', '/api/foo/b-123/bar').params, { id: 'b-123' })
+})


### PR DESCRIPTION
This is causing issues resulting in nodes not having a parametric brother as witnessed in #110 

`node bench.js` result:

**Master**
```
lookup static route x 36,805,474 ops/sec ±1.94% (83 runs sampled)
lookup dynamic route x 3,062,199 ops/sec ±1.85% (87 runs sampled)
lookup dynamic multi-parametric route x 1,681,604 ops/sec ±1.76% (85 runs sampled)
lookup dynamic multi-parametric route with regex x 1,319,392 ops/sec ±1.05% (88 runs sampled)
lookup long static route x 2,975,863 ops/sec ±0.85% (90 runs sampled)
lookup long dynamic route x 2,116,684 ops/sec ±0.90% (91 runs sampled)
lookup static versioned route x 7,842,228 ops/sec ±0.87% (91 runs sampled)
find static route x 38,501,099 ops/sec ±0.69% (94 runs sampled)
find dynamic route x 4,113,594 ops/sec ±0.60% (93 runs sampled)
find dynamic multi-parametric route x 2,103,203 ops/sec ±0.49% (92 runs sampled)
find dynamic multi-parametric route with regex x 1,477,187 ops/sec ±1.99% (89 runs sampled)
find long static route x 4,517,911 ops/sec ±0.66% (92 runs sampled)
find long dynamic route x 3,026,659 ops/sec ±1.22% (92 runs sampled)
find static versioned route x 9,621,962 ops/sec ±1.94% (83 runs sampled)
```

**issue-110**

```
lookup static route x 37,693,101 ops/sec ±1.50% (84 runs sampled)
lookup dynamic route x 2,985,300 ops/sec ±1.75% (88 runs sampled)
lookup dynamic multi-parametric route x 1,671,388 ops/sec ±1.52% (87 runs sampled)
lookup dynamic multi-parametric route with regex x 1,278,199 ops/sec ±0.93% (88 runs sampled)
lookup long static route x 2,951,359 ops/sec ±1.04% (88 runs sampled)
lookup long dynamic route x 2,093,028 ops/sec ±1.35% (91 runs sampled)
lookup static versioned route x 7,783,319 ops/sec ±1.04% (88 runs sampled)
find static route x 35,585,628 ops/sec ±1.36% (88 runs sampled)
find dynamic route x 3,862,732 ops/sec ±1.30% (86 runs sampled)
find dynamic multi-parametric route x 1,935,518 ops/sec ±1.27% (85 runs sampled)
find dynamic multi-parametric route with regex x 1,367,140 ops/sec ±1.75% (87 runs sampled)
find long static route x 4,277,721 ops/sec ±1.44% (89 runs sampled)
find long dynamic route x 2,879,483 ops/sec ±1.88% (88 runs sampled)
find static versioned route x 9,989,308 ops/sec ±2.24% (86 runs sampled)
```