### PR TITLE
Lock tap to v12.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pre-commit": "^1.2.2",
     "request": "^2.88.0",
     "standard": "^12.0.1",
-    "tap": "^12.0.1",
+    "tap": "12.0.1",
     "typescript": "^3.2.1"
   },
   "dependencies": {


### PR DESCRIPTION
Tap 12.0.1 still support Node v4. Latest versions do not anymore.