### PR TITLE
preserve param values case in case insensitive mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -340,24 +340,27 @@ Router.prototype.lookup = function lookup (req, res, ctx) {
 }
 
 Router.prototype.find = function find (method, path, version) {
-  if (this.caseSensitive === false) {
-    path = path.toLowerCase()
-  }
-
   if (path.charCodeAt(0) !== 47) { // 47 is '/'
     path = path.replace(FULL_PATH_REGEXP, '/')
   }
 
+  var originalPath = path
+  var originalPathLength = path.length
+
+  if (this.caseSensitive === false) {
+    path = path.toLowerCase()
+  }
+
+  var encodedPath
   var maxParamLength = this.maxParamLength
   var currentNode = this.tree
   var wildcardNode = null
   var pathLenWildcard = 0
-  var originalPath = path
-  var originalPathLength = path.length
   var decoded = null
   var pindex = 0
   var params = []
   var i = 0
+  var idxInOriginalPath = 0
 
   while (true) {
     var pathLen = path.length
@@ -365,7 +368,6 @@ Router.prototype.find = function find (method, path, version) {
     var prefixLen = prefix.length
     var len = 0
     var previousPath = path
-
     // found the route
     if (pathLen === 0 || path === prefix) {
       var handle = version === undefined
@@ -396,6 +398,7 @@ Router.prototype.find = function find (method, path, version) {
     if (len === prefixLen) {
       path = path.slice(len)
       pathLen = path.length
+      idxInOriginalPath += len
     }
 
     var node = version === undefined
@@ -415,10 +418,13 @@ Router.prototype.find = function find (method, path, version) {
         var pathDiff = originalPath.slice(0, originalPathLength - pathLen)
         previousPath = pathDiff.slice(pathDiff.lastIndexOf('/') + 1, pathDiff.length) + path
       }
+      idxInOriginalPath = idxInOriginalPath -
+        (previousPath.length - path.length)
       path = previousPath
       pathLen = previousPath.length
       len = prefixLen
     }
+
     var kind = node.kind
 
     // static route
@@ -442,46 +448,8 @@ Router.prototype.find = function find (method, path, version) {
       pathLenWildcard = pathLen
     }
 
-    // parametric route
-    if (kind === NODE_TYPES.PARAM) {
-      currentNode = node
-      i = path.indexOf('/')
-      if (i === -1) i = pathLen
-      if (i > maxParamLength) return null
-      decoded = fastDecode(path.slice(0, i))
-      if (decoded === null) return null
-      params[pindex++] = decoded
-      path = path.slice(i)
-      continue
-    }
-
-    // wildcard route
-    if (kind === NODE_TYPES.MATCH_ALL) {
-      decoded = fastDecode(path)
-      if (decoded === null) return null
-      params[pindex] = decoded
-      currentNode = node
-      path = ''
-      continue
-    }
-
-    // parametric(regex) route
-    if (kind === NODE_TYPES.REGEX) {
-      currentNode = node
-      i = path.indexOf('/')
-      if (i === -1) i = pathLen
-      if (i > maxParamLength) return null
-      decoded = fastDecode(path.slice(0, i))
-      if (decoded === null) return null
-      if (!node.regex.test(decoded)) return null
-      params[pindex++] = decoded
-      path = path.slice(i)
-      continue
-    }
-
-    // multiparametric route
+    currentNode = node
     if (kind === NODE_TYPES.MULTI_PARAM) {
-      currentNode = node
       i = 0
       if (node.regex !== null) {
         var matchedParameter = path.match(node.regex)
@@ -491,14 +459,21 @@ Router.prototype.find = function find (method, path, version) {
         while (i < pathLen && path.charCodeAt(i) !== 47 && path.charCodeAt(i) !== 45) i++
         if (i > maxParamLength) return null
       }
-      decoded = fastDecode(path.slice(0, i))
-      if (decoded === null) return null
-      params[pindex++] = decoded
-      path = path.slice(i)
-      continue
+    } else if (kind === NODE_TYPES.MATCH_ALL) {
+      i = pathLen
+    } else {
+      i = path.indexOf('/')
     }
 
-    wildcardNode = null
+    if (i === -1) i = pathLen
+    if (i > maxParamLength) return null
+    encodedPath = originalPath.slice(idxInOriginalPath, idxInOriginalPath + i)
+    decoded = fastDecode(encodedPath)
+    if (decoded === null) return null
+    if (kind === NODE_TYPES.REGEX && !node.regex.test(decoded)) return null
+    params[pindex++] = decoded
+    path = path.slice(i)
+    idxInOriginalPath += i
   }
 }
 

--- a/test/case-insensitive.test.js
+++ b/test/case-insensitive.test.js
@@ -21,6 +21,23 @@ test('case insensitive static routes of level 1', t => {
   findMyWay.lookup({ method: 'GET', url: '/WOO', headers: {} }, null)
 })
 
+test('case insensitive static routes of level 2', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay({
+    caseSensitive: false,
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/foo/woo', (req, res, params) => {
+    t.pass('we should be here')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/FoO/WOO', headers: {} }, null)
+})
+
 test('case insensitive static routes of level 3', t => {
   t.plan(1)
 
@@ -49,7 +66,7 @@ test('parametric case insensitive', t => {
   })
 
   findMyWay.on('GET', '/foo/:param', (req, res, params) => {
-    t.equal(params.param, 'bar')
+    t.equal(params.param, 'bAR')
   })
 
   findMyWay.lookup({ method: 'GET', url: '/Foo/bAR', headers: {} }, null)
@@ -66,7 +83,7 @@ test('parametric case insensitive with a static part', t => {
   })
 
   findMyWay.on('GET', '/foo/my-:param', (req, res, params) => {
-    t.equal(params.param, 'bar')
+    t.equal(params.param, 'bAR')
   })
 
   findMyWay.lookup({ method: 'GET', url: '/Foo/MY-bAR', headers: {} }, null)
@@ -83,7 +100,7 @@ test('parametric case insensitive with capital letter', t => {
   })
 
   findMyWay.on('GET', '/foo/:Param', (req, res, params) => {
-    t.equal(params.Param, 'bar')
+    t.equal(params.Param, 'bAR')
   })
 
   findMyWay.lookup({ method: 'GET', url: '/Foo/bAR', headers: {} }, null)
@@ -100,10 +117,10 @@ test('case insensitive with capital letter in static path with param', t => {
   })
 
   findMyWay.on('GET', '/Foo/bar/:param', (req, res, params) => {
-    t.equal(params.param, 'baz')
+    t.equal(params.param, 'baZ')
   })
 
-  findMyWay.lookup({ method: 'GET', url: '/Foo/bar/baz', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/foo/bar/baZ', headers: {} }, null)
 })
 
 test('case insensitive with multiple paths containing capital letter in static path with param', t => {
@@ -121,13 +138,66 @@ test('case insensitive with multiple paths containing capital letter in static p
   })
 
   findMyWay.on('GET', '/Foo/bar/:param', (req, res, params) => {
-    t.equal(params.param, 'baz')
+    t.equal(params.param, 'baZ')
   })
 
   findMyWay.on('GET', '/Foo/baz/:param', (req, res, params) => {
-    t.equal(params.param, 'bar')
+    t.equal(params.param, 'baR')
   })
 
-  findMyWay.lookup({ method: 'GET', url: '/Foo/bar/baz', headers: {} }, null)
-  findMyWay.lookup({ method: 'GET', url: '/Foo/baz/bar', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/foo/bar/baZ', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/foo/baz/baR', headers: {} }, null)
+})
+
+test('case insensitive with multiple mixed-case params within same slash couple', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay({
+    caseSensitive: false,
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/foo/:param1-:param2', (req, res, params) => {
+    t.equal(params.param1, 'My')
+    t.equal(params.param2, 'bAR')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/FOO/My-bAR', headers: {} }, null)
+})
+
+test('case insensitive with multiple mixed-case params', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay({
+    caseSensitive: false,
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/foo/:param1/:param2', (req, res, params) => {
+    t.equal(params.param1, 'My')
+    t.equal(params.param2, 'bAR')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/FOO/My/bAR', headers: {} }, null)
+})
+
+test('case insensitive with wildcard', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay({
+    caseSensitive: false,
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/foo/*', (req, res, params) => {
+    t.equal(params['*'], 'baR')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/FOO/baR', headers: {} }, null)
 })


### PR DESCRIPTION
This PR has the same goal as https://github.com/delvedor/find-my-way/pull/99, but is solving the problem using a different approach in an effort to get a better performance profile.

Using node v10.14.1 I get the following results on the current tip of the master branch:

```
$ node bench.js 
lookup static route x 47,169,425 ops/sec ±0.44% (92 runs sampled)
lookup dynamic route x 3,518,794 ops/sec ±1.27% (94 runs sampled)
lookup dynamic multi-parametric route x 1,959,970 ops/sec ±1.18% (91 runs sampled)
lookup dynamic multi-parametric route with regex x 1,485,289 ops/sec ±1.04% (95 runs sampled)
lookup long static route x 3,359,776 ops/sec ±0.51% (93 runs sampled)
lookup long dynamic route x 2,326,569 ops/sec ±0.88% (94 runs sampled)
lookup static versioned route x 8,826,650 ops/sec ±0.36% (94 runs sampled)
find static route x 40,171,616 ops/sec ±0.36% (94 runs sampled)
find dynamic route x 4,323,841 ops/sec ±0.46% (94 runs sampled)
find dynamic multi-parametric route x 2,230,310 ops/sec ±0.95% (91 runs sampled)
find dynamic multi-parametric route with regex x 1,612,491 ops/sec ±1.48% (94 runs sampled)
find long static route x 5,095,209 ops/sec ±0.49% (92 runs sampled)
find long dynamic route x 3,274,189 ops/sec ±1.00% (93 runs sampled)
find static versioned route x 12,199,768 ops/sec ±0.47% (91 runs sampled)
$
```

and the following results with the changes in this PR:

```
$ node bench.js 
lookup static route x 46,944,968 ops/sec ±0.50% (94 runs sampled)
lookup dynamic route x 3,446,964 ops/sec ±1.12% (93 runs sampled)
lookup dynamic multi-parametric route x 1,939,438 ops/sec ±1.35% (86 runs sampled)
lookup dynamic multi-parametric route with regex x 1,492,556 ops/sec ±0.73% (93 runs sampled)
lookup long static route x 3,396,039 ops/sec ±0.70% (92 runs sampled)
lookup long dynamic route x 2,359,074 ops/sec ±1.04% (95 runs sampled)
lookup static versioned route x 9,666,929 ops/sec ±0.51% (94 runs sampled)
find static route x 40,421,353 ops/sec ±0.30% (93 runs sampled)
find dynamic route x 4,331,766 ops/sec ±0.89% (92 runs sampled)
find dynamic multi-parametric route x 2,343,994 ops/sec ±1.23% (89 runs sampled)
find dynamic multi-parametric route with regex x 1,663,532 ops/sec ±0.28% (93 runs sampled)
find long static route x 5,093,791 ops/sec ±0.56% (89 runs sampled)
find long dynamic route x 3,361,727 ops/sec ±0.55% (92 runs sampled)
find static versioned route x 12,483,715 ops/sec ±0.73% (94 runs sampled)
$ 
```

It _seems_ like this is a better change performance-wise, and like it could potentially avoids some code duplication, so I thought I'd submit this in case that looks like an acceptable change.