### PR TITLE
fix error under --disallow-code-generation-from-strings

### DIFF
--- a/node.js
+++ b/node.js
@@ -234,7 +234,18 @@ function buildHandlers (handlers) {
     code += `this['${m}'] = handlers['${m}'] || null
     `
   }
-  return new Function('handlers', code) // eslint-disable-line
+
+  try {
+    return new Function('handlers', code) // eslint-disable-line
+  } catch(e) {
+    return function(_handlers) {
+      _handlers = _handlers || {};
+      for (var i = 0; i < http.METHODS.length; i++) {
+        var m = http.METHODS[i];
+        this[m] = _handlers[m] || null;
+      }
+    };
+  }
 }
 
 module.exports = Node

--- a/node.js
+++ b/node.js
@@ -237,14 +237,14 @@ function buildHandlers (handlers) {
 
   try {
     return new Function('handlers', code) // eslint-disable-line
-  } catch(e) {
-    return function(_handlers) {
-      _handlers = _handlers || {};
+  } catch (e) {
+    return function (_handlers) {
+      _handlers = _handlers || {}
       for (var i = 0; i < http.METHODS.length; i++) {
-        var m = http.METHODS[i];
-        this[m] = _handlers[m] || null;
+        var m = http.METHODS[i]
+        this[m] = _handlers[m] || null
       }
-    };
+    }
   }
 }
 


### PR DESCRIPTION
Hi, 

I'm trying to use find-my-way in a security-critical environment where I have to run node with the --disallow-code-generation-from-strings flag. Under this flag, calls to `new Function` error, preventing me from using find-my-way.

This PR adds a fallback approach in the `buildHandlers` function for when `new Function` errors. Because `buildHandlers` is only called once, having this fallback has essentially zero performance impact on people running in contexts where `new Function` is allowed. (They get the exact same handlers functions they were getting before.)

For the few people running under the --disallow-code-generation-from-strings flag, the fallback approach is certainly slower than the eval approach (it brings down the library's overall performance by ~8% on the router-benchmarks suite), but having code that works a bit slower seems far better than blowing up entirely.