### PR TITLE
fix prettyPrint indent

### DIFF
--- a/node.js
+++ b/node.js
@@ -203,7 +203,7 @@ Node.prototype.prettyPrint = function (prefix, tail) {
           paramName += param + ` (${method})\n`
           return
         }
-        paramName += '    ' + prefix + ':' + param + ` (${method})`
+        paramName += prefix + '    :' + param + ` (${method})`
         paramName += (index === methods.length - 1 ? '' : '\n')
       } else {
         paramName = params[params.length - 1] + ` (${method})`

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -90,3 +90,27 @@ test('pretty print - wildcard routes', t => {
   t.is(typeof tree, 'string')
   t.equal(tree, expected)
 })
+
+test('pretty print - parametric routes with same parent and followed by a static route which has the same prefix with the former routes', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+  findMyWay.on('GET', '/test', () => {})
+  findMyWay.on('GET', '/test/hello/:id', () => {})
+  findMyWay.on('POST', '/test/hello/:id', () => {})
+  findMyWay.on('GET', '/test/helloworld', () => {})
+
+  const tree = findMyWay.prettyPrint()
+
+  const expected = `└── /
+    └── test (GET)
+        └── /hello
+            ├── /
+            │   └── :id (GET)
+            │       :id (POST)
+            └── world (GET)
+`
+
+  t.is(typeof tree, 'string')
+  t.equal(tree, expected)
+})


### PR DESCRIPTION
fix #129

It outputs the following:
![5P10B82%$6S$32QNT @61SY](https://user-images.githubusercontent.com/20400873/63237271-dc9fd280-c273-11e9-84f5-5cbbeae51bc6.png)
