### PR TITLE
Added support for onBadUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ const router = require('find-my-way')({
 })
 ```
 
+In case of a badly formatted url *(eg: `/hello/%world`)*, by default `find-my-way` will invoke the `defaultRoute`, unless you specify the `onBadUrl` option:
+```js
+const router = require('find-my-way')({
+  onBadUrl: (path, req, res) => {
+    res.statusCode = 400
+    res.end(`Bad path: ${path}`)
+  }
+})
+```
+
 Trailing slashes can be ignored by supplying the `ignoreTrailingSlash` option:
 ```js
 const router = require('find-my-way')({
@@ -347,21 +357,21 @@ findMyWay.on('GET', '/test/hello', () => {})
 
 console.log(findMyWay.routes)
 // Will print
-// [ 
-//   { 
+// [
+//   {
 //     method: 'GET',
 //     path: '/test',
 //     opts: {},
 //     handler: [Function],
-//     store: undefined 
+//     store: undefined
 //   },
-//   { 
+//   {
 //     method: 'GET',
 //     path: '/test/hello',
 //     opts: {},
 //     handler: [Function],
-//     store: undefined 
-//   } 
+//     store: undefined
+//   }
 // ]
 ```
 

--- a/test/on-bad-url.test.js
+++ b/test/on-bad-url.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+
+test('If onBadUrl is defined, then a bad url should be handled differently (find)', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    },
+    onBadUrl: (path, req, res) => {
+      t.strictEqual(path, '/%world')
+    }
+  })
+
+  findMyWay.on('GET', '/hello/:id', (req, res) => {
+    t.fail('Should not be here')
+  })
+
+  const handle = findMyWay.find('GET', '/hello/%world')
+  t.notStrictEqual(handle, null)
+})
+
+test('If onBadUrl is defined, then a bad url should be handled differently (lookup)', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    },
+    onBadUrl: (path, req, res) => {
+      t.strictEqual(path, '%world')
+    }
+  })
+
+  findMyWay.on('GET', '/hello/:id', (req, res) => {
+    t.fail('Should not be here')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/hello/%world', headers: {} }, null)
+})
+
+test('If onBadUrl is not defined, then we should call the defaultRoute (find)', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/hello/:id', (req, res) => {
+    t.fail('Should not be here')
+  })
+
+  const handle = findMyWay.find('GET', '/hello/%world')
+  t.strictEqual(handle, null)
+})
+
+test('If onBadUrl is not defined, then we should call the defaultRoute (lookup)', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.pass('Everything fine')
+    }
+  })
+
+  findMyWay.on('GET', '/hello/:id', (req, res) => {
+    t.fail('Should not be here')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/hello/%world', headers: {} }, null)
+})


### PR DESCRIPTION
Now `find-my-way` offers the support for a separate handler in case of a bad url. If it's not configured, the behavior will be the same as before, which means calling the `defaultRoute` in case of the `lookup` and returning `null` in case of `find`.

Usage:
```js
const router = require('find-my-way')({
  onBadUrl: (path, req, res) => {
    res.statusCode = 400
    res.end(`Bad path: ${path}`)
  }
})
```

Related: https://github.com/fastify/fastify/issues/1884