### PR TITLE
Pretty print improvements

### DIFF
--- a/node.js
+++ b/node.js
@@ -190,15 +190,16 @@ Node.prototype.getVersionHandler = function (version, method) {
   return handlers === null ? handlers : handlers[method]
 }
 
-Node.prototype.prettyPrintNew = function () {
+Node.prototype.prettyPrint = function () {
   const tree = { ...this }
   traverseTree(tree)
 
   // Moneky patch needed for the routes that have multiple handlers
   return archy(tree)
     .replace(/─┬/g, '')
-    .replace(/│ ├── &/g, '├── ')
-    .replace(/│ └── &/g, '├── ')
+    .replace(/│ ├── & /g, '├── ')
+    .replace(/│ └── & /g, '├── ')
+    .replace(/ & /g, ' ')
 }
 
 function traverseTree (node) {
@@ -223,9 +224,9 @@ function traverseTree (node) {
         let label
         // The & is to later find this branches and fix them
         if (node.prefix === ':') {
-          label = `&:${route[1].params.join()} (${route[0]}) ${route[0][1].handler.name}`
+          label = `& :${route[1].params.join()} (${route[0]}) ${route[1].handler.name}`
         } else {
-          label = `&(${route[0]}) ${route[0][1].handler.name}`
+          label = `& (${route[0]}) ${route[1].handler.name}`
         }
 
         return { label: label }
@@ -244,43 +245,6 @@ function traverseTree (node) {
 
 function mapChildredToArray (children) {
   return Object.keys(children).map(i => children[i])
-}
-
-Node.prototype.prettyPrint = function (prefix, tail) {
-  var paramName = ''
-  var handlers = this.handlers || {}
-  var methods = Object.keys(handlers).filter(method => handlers[method] && handlers[method].handler)
-
-  if (this.prefix === ':') {
-    methods.forEach((method, index) => {
-      var params = this.handlers[method].params
-      var param = params[params.length - 1]
-      if (methods.length > 1) {
-        if (index === 0) {
-          paramName += param + ` (${method})\n`
-          return
-        }
-        paramName += prefix + '    :' + param + ` (${method})`
-        paramName += (index === methods.length - 1 ? '' : '\n')
-      } else {
-        paramName = params[params.length - 1] + ` (${method})`
-      }
-    })
-  } else if (methods.length) {
-    paramName = ` (${methods.join('|')})`
-  }
-
-  var tree = `${prefix}${tail ? '└── ' : '├── '}${this.prefix}${paramName}\n`
-
-  prefix = `${prefix}${tail ? '    ' : '│   '}`
-  const labels = Object.keys(this.children)
-  for (var i = 0; i < labels.length - 1; i++) {
-    tree += this.children[labels[i]].prettyPrint(prefix, false)
-  }
-  if (labels.length > 0) {
-    tree += this.children[labels[labels.length - 1]].prettyPrint(prefix, true)
-  }
-  return tree
 }
 
 function buildHandlers (handlers) {

--- a/node.js
+++ b/node.js
@@ -212,9 +212,9 @@ function traverseTree (node) {
   } else if (routes.length === 1) {
     const currentRoute = routes[0]
     if (node.prefix === ':') {
-      node.label = `:${currentRoute[1].params.join(':')} (${currentRoute[0]})`
+      node.label = `:${currentRoute[1].params.join(':')} (${currentRoute[0]}) ${currentRoute[1].handler.name}`
     } else {
-      node.label = `${node.prefix} (${currentRoute[0]})`
+      node.label = `${node.prefix} (${currentRoute[0]}) ${currentRoute[1].handler.name}`
     }
   } else {
     node.label = archy({
@@ -223,9 +223,9 @@ function traverseTree (node) {
         let label
         // The & is to later find this branches and fix them
         if (node.prefix === ':') {
-          label = `&:${route[1].params.join()} (${route[0]})`
+          label = `&:${route[1].params.join()} (${route[0]}) ${route[0][1].handler.name}`
         } else {
-          label = `&(${route[0]})`
+          label = `&(${route[0]}) ${route[0][1].handler.name}`
         }
 
         return { label: label }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "typescript": "^3.3.3"
   },
   "dependencies": {
+    "archy": "^1.0.0",
     "fast-decode-uri-component": "^1.0.0",
     "safe-regex2": "^2.0.0",
     "semver-store": "^0.3.0"

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -114,3 +114,24 @@ test('pretty print - parametric routes with same parent and followed by a static
   t.is(typeof tree, 'string')
   t.equal(tree, expected)
 })
+
+test('pretty print - handle multiple handlers in parametric route properly', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+  findMyWay.on('GET', '/:a', () => {})
+  findMyWay.on('POST', '/:b', () => {})
+  findMyWay.on('POST', '/c', () => {})
+
+  const tree = findMyWay.prettyPrint()
+
+  const expected = `/
+  ├── :
+  │   ├── :a (GET) 
+  │   └── :b (POST) 
+  │   
+  └── c (POST) `
+
+  t.is(typeof tree, 'string')
+  t.equal(tree, expected)
+})

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -14,10 +14,10 @@ test('pretty print - static routes', t => {
 
   const tree = findMyWay.prettyPrint()
 
-  const expected = `└── /
-    ├── test (GET)
-    │   └── /hello (GET)
-    └── hello/world (GET)
+  const expected = `/
+├ test (GET) 
+│ └── /hello (GET) 
+└── hello/world (GET) 
 `
 
   t.is(typeof tree, 'string')
@@ -34,12 +34,12 @@ test('pretty print - parametric routes', t => {
 
   const tree = findMyWay.prettyPrint()
 
-  const expected = `└── /
-    ├── test (GET)
-    │   └── /
-    │       └── :hello (GET)
-    └── hello/
-        └── :world (GET)
+  const expected = `/
+├ test (GET) 
+│ └ /
+│   └── :hello (GET) 
+└ hello/
+  └── :world (GET) 
 `
 
   t.is(typeof tree, 'string')
@@ -57,12 +57,14 @@ test('pretty print - mixed parametric routes', t => {
 
   const tree = findMyWay.prettyPrint()
 
-  const expected = `└── /
-    └── test (GET)
-        └── /
-            └── :hello (GET)
-                :hello (POST)
-                └── /world (GET)
+  const expected = `/
+└ test (GET) 
+  └ /
+    └ :
+      ├── :hello (GET) 
+      ├── :hello (POST) 
+      │ 
+      └── /world (GET) 
 `
 
   t.is(typeof tree, 'string')
@@ -79,12 +81,12 @@ test('pretty print - wildcard routes', t => {
 
   const tree = findMyWay.prettyPrint()
 
-  const expected = `└── /
-    ├── test (GET)
-    │   └── /
-    │       └── * (GET)
-    └── hello/
-        └── * (GET)
+  const expected = `/
+├ test (GET) 
+│ └ /
+│   └── * (GET) 
+└ hello/
+  └── * (GET) 
 `
 
   t.is(typeof tree, 'string')
@@ -102,13 +104,15 @@ test('pretty print - parametric routes with same parent and followed by a static
 
   const tree = findMyWay.prettyPrint()
 
-  const expected = `└── /
-    └── test (GET)
-        └── /hello
-            ├── /
-            │   └── :id (GET)
-            │       :id (POST)
-            └── world (GET)
+  const expected = `/
+└ test (GET) 
+  └ /hello
+    ├ /
+    │ └── :
+    │     ├── :id (GET) 
+    │     └── :id (POST) 
+    │     
+    └── world (GET) 
 `
 
   t.is(typeof tree, 'string')
@@ -126,11 +130,34 @@ test('pretty print - handle multiple handlers in parametric route properly', t =
   const tree = findMyWay.prettyPrint()
 
   const expected = `/
-  ├── :
-  │   ├── :a (GET) 
-  │   └── :b (POST) 
-  │   
-  └── c (POST) `
+├── :
+│   ├── :a (GET) 
+│   └── :b (POST) 
+│   
+└── c (POST) 
+`
+
+  t.is(typeof tree, 'string')
+  t.equal(tree, expected)
+})
+
+test('pretty print - log handler`s name', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+  findMyWay.on('GET', '/:a', function functionA () {})
+  findMyWay.on('POST', '/:b', function functionB () {})
+  findMyWay.on('POST', '/c', function functionC () {})
+
+  const tree = findMyWay.prettyPrint()
+
+  const expected = `/
+├── :
+│   ├── :a (GET) functionA
+│   └── :b (POST) functionB
+│   
+└── c (POST) functionC
+`
 
   t.is(typeof tree, 'string')
   t.equal(tree, expected)


### PR DESCRIPTION
- Replacement of PR #138, addressing [this comment](https://github.com/delvedor/find-my-way/pull/138#discussion_r341846274) which it was something not implemented in that PR
- Uses `node-archy` addressing [this comment](https://github.com/delvedor/find-my-way/issues/82#issuecomment-401153583)
  - Fix the following bug and added a test to cover it
  ```
  └── /
    ├── :a (GET)
        :b (PUT)         <- Character missing
    └── c/
        └── :c (GET)
  ```
- Added test to cover the new feature and updated old ones (since they all broke)
- Does not fix bug [#82](https://github.com/delvedor/find-my-way/issues/82)
- If merged, [fastify#2048](https://github.com/fastify/fastify/pull/2048) will be affected

### Output differences

```
before
└── / (GET|POST)
    ├── a (GET|PUT)
    │   └── /
    │       ├── :a (GET)
    │       └── b (GET)
    ├── b (GET)
    └── :test (GET)
        :test (PUT)
        └── /hello (GET)
```

```
after
/
├── (GET)
├── (POST)
│ 
├ a
│ ├── (GET)
│ ├── (PUT)
│ │ 
│ └ /
│   ├── :a (GET)
│   └── b (GET)
├── b (GET)
└ :                         <- Note here, this is diferent that before
  ├── :test (GET)
  ├── :test (PUT)
  │ 
  └── /hello (GET)

```


I had to do some monkey patching because the part of the tree generated by `archy` would not look good, not proud of that code but it works.

To be honest, I like the original output more but this new approach allows for the handler's name to be displayed.
