### PR TITLE
Relax version check

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
   assert(httpMethods.indexOf(method) !== -1, `Method '${method}' is not an http method.`)
 
   // version validation
-  if (opts.hasOwnProperty('version')) {
+  if (opts.version !== undefined) {
     assert(typeof opts.version === 'string', 'Version should be a string')
   }
 

--- a/test/issue-154.test.js
+++ b/test/issue-154.test.js
@@ -6,14 +6,17 @@ const FindMyWay = require('..')
 const noop = () => {}
 
 test('Should throw when not sending a string', t => {
-  t.plan(2)
+  t.plan(3)
 
   const findMyWay = FindMyWay()
 
   t.throws(() => {
-    findMyWay.on('GET', '/t1', { version: undefined }, noop)
+    findMyWay.on('GET', '/t1', { version: 42 }, noop)
   })
   t.throws(() => {
     findMyWay.on('GET', '/t2', { version: null }, noop)
+  })
+  t.throws(() => {
+    findMyWay.on('GET', '/t2', { version: true }, noop)
   })
 })


### PR DESCRIPTION
In #155 we have introduces a version check that is to strict and it's breaking Fastify [here](https://github.com/fastify/fastify/blob/521781db9f25eb5dfd5b61f19b2f0fc0137ee913/lib/route.js#L221).
This fix relaxes the check as the rest of the code does not handle undefined versions.