### PR TITLE
Fix path params match issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,7 +428,7 @@ Router.prototype.find = function find (method, path, version) {
         return this._getWildcardNode(wildcardNode, method, originalPath, pathLenWildcard)
       }
 
-      var goBack = this.ignoreTrailingSlash ? previousPath : '/' + previousPath
+      var goBack = previousPath.charCodeAt(0) === 47 ? previousPath : '/' + previousPath
       if (originalPath.indexOf(goBack) === -1) {
         // we need to know the outstanding path so far from the originalPath since the last encountered "/" and assign it to previousPath.
         // e.g originalPath: /aa/bbb/cc, path: bb/cc

--- a/test/path-params-match.test.js
+++ b/test/path-params-match.test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const t = require('tap')
+const FindMyWay = require('../')
+
+t.test('path params match', (t) => {
+  t.plan(12)
+
+  const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
+
+  const b1Path = function b1StaticPath () {}
+  const b2Path = function b2StaticPath () {}
+  const cPath = function cStaticPath () {}
+  const paramPath = function parameterPath () {}
+
+  findMyWay.on('GET', '/ab1', b1Path)
+  findMyWay.on('GET', '/ab2', b2Path)
+  findMyWay.on('GET', '/ac', cPath)
+  findMyWay.on('GET', '/:pam', paramPath)
+
+  t.equals(findMyWay.find('GET', '/ab1').handler, b1Path)
+  t.equals(findMyWay.find('GET', '/ab1/').handler, b1Path)
+  t.equals(findMyWay.find('GET', '/ab2').handler, b2Path)
+  t.equals(findMyWay.find('GET', '/ab2/').handler, b2Path)
+  t.equals(findMyWay.find('GET', '/ac').handler, cPath)
+  t.equals(findMyWay.find('GET', '/ac/').handler, cPath)
+  t.equals(findMyWay.find('GET', '/foo').handler, paramPath)
+  t.equals(findMyWay.find('GET', '/foo/').handler, paramPath)
+
+  const noTrailingSlashRet = findMyWay.find('GET', '/abcdef')
+  t.equals(noTrailingSlashRet.handler, paramPath)
+  t.deepEqual(noTrailingSlashRet.params, { pam: 'abcdef' })
+
+  const trailingSlashRet = findMyWay.find('GET', '/abcdef/')
+  t.equals(trailingSlashRet.handler, paramPath)
+  t.deepEqual(trailingSlashRet.params, { pam: 'abcdef' })
+})


### PR DESCRIPTION
# Precondition

- static route `/ab1`
- static route `/ab2`
- static route `/ac`
- parametric route `/:params`
- request path `/abcdef`

# Expect

```javascript
// params
{ params: 'abcdef' }
```

# Actual

```javascript
// params
{ params: 'bcdef'}
```

# Related issues

#145 

# Bench Results

```
> node bench.js

lookup static route x 44,313,098 ops/sec ±0.73% (584 runs sampled)
lookup dynamic route x 3,390,240 ops/sec ±0.97% (583 runs sampled)
lookup dynamic multi-parametric route x 1,832,331 ops/sec ±0.47% (578 runs sampled)
lookup dynamic multi-parametric route with regex x 1,309,854 ops/sec ±0.37% (586 runs sampled)
lookup long static route x 3,282,500 ops/sec ±0.72% (591 runs sampled)
lookup long dynamic route x 2,423,513 ops/sec ±0.49% (590 runs sampled)
lookup static versioned route x 8,511,010 ops/sec ±0.47% (590 runs sampled)
find static route x 44,480,616 ops/sec ±0.34% (590 runs sampled)
find dynamic route x 3,888,604 ops/sec ±1.54% (568 runs sampled)
find dynamic multi-parametric route x 2,370,472 ops/sec ±0.88% (585 runs sampled)
find dynamic multi-parametric route with regex x 1,819,445 ops/sec ±0.47% (591 runs sampled)
find long static route x 5,062,864 ops/sec ±0.33% (590 runs sampled)
find long dynamic route x 3,740,761 ops/sec ±0.33% (591 runs sampled)
find static versioned route x 10,959,874 ops/sec ±0.36% (591 runs sampled)
```