### PR TITLE
Fix path params match issue (#159)

### DIFF
--- a/index.js
+++ b/index.js
@@ -421,7 +421,7 @@ Router.prototype.find = function find (method, path, version) {
         return this._getWildcardNode(wildcardNode, method, originalPath, pathLenWildcard)
       }
 
-      var goBack = this.ignoreTrailingSlash ? previousPath : '/' + previousPath
+      var goBack = previousPath.charCodeAt(0) === 47 ? previousPath : '/' + previousPath
       if (originalPath.indexOf(goBack) === -1) {
         // we need to know the outstanding path so far from the originalPath since the last encountered "/" and assign it to previousPath.
         // e.g originalPath: /aa/bbb/cc, path: bb/cc

--- a/test/path-params-match.test.js
+++ b/test/path-params-match.test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const t = require('tap')
+const FindMyWay = require('../')
+
+t.test('path params match', (t) => {
+  t.plan(12)
+
+  const findMyWay = FindMyWay({ ignoreTrailingSlash: true })
+
+  const b1Path = function b1StaticPath () {}
+  const b2Path = function b2StaticPath () {}
+  const cPath = function cStaticPath () {}
+  const paramPath = function parameterPath () {}
+
+  findMyWay.on('GET', '/ab1', b1Path)
+  findMyWay.on('GET', '/ab2', b2Path)
+  findMyWay.on('GET', '/ac', cPath)
+  findMyWay.on('GET', '/:pam', paramPath)
+
+  t.equals(findMyWay.find('GET', '/ab1').handler, b1Path)
+  t.equals(findMyWay.find('GET', '/ab1/').handler, b1Path)
+  t.equals(findMyWay.find('GET', '/ab2').handler, b2Path)
+  t.equals(findMyWay.find('GET', '/ab2/').handler, b2Path)
+  t.equals(findMyWay.find('GET', '/ac').handler, cPath)
+  t.equals(findMyWay.find('GET', '/ac/').handler, cPath)
+  t.equals(findMyWay.find('GET', '/foo').handler, paramPath)
+  t.equals(findMyWay.find('GET', '/foo/').handler, paramPath)
+
+  const noTrailingSlashRet = findMyWay.find('GET', '/abcdef')
+  t.equals(noTrailingSlashRet.handler, paramPath)
+  t.deepEqual(noTrailingSlashRet.params, { pam: 'abcdef' })
+
+  const trailingSlashRet = findMyWay.find('GET', '/abcdef/')
+  t.equals(trailingSlashRet.handler, paramPath)
+  t.deepEqual(trailingSlashRet.params, { pam: 'abcdef' })
+})


### PR DESCRIPTION
For [node-restify](https://github.com/restify/node-restify#supported-node-versions), Node 8.x is the supported version, so I cherry-pick a commit(#159 ) to 2.x branch. Thanks.