### PR TITLE
Request based constraints implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -389,9 +389,7 @@ Router.prototype.find = function find (method, path, constraintsExtractor) {
     var previousPath = path
     // found the route
     if (pathLen === 0 || path === prefix) {
-      var handle = version === undefined
-        ? currentNode.handlers[method]
-        : currentNode.getVersionHandler(version, method)
+      var handle = currentNode.getMatchingHandler(constraintsExtractor, method)
       if (handle !== null && handle !== undefined) {
         var paramsObj = {}
         if (handle.paramsLength > 0) {
@@ -420,9 +418,7 @@ Router.prototype.find = function find (method, path, constraintsExtractor) {
       idxInOriginalPath += len
     }
 
-    var node = version === undefined
-      ? currentNode.findChild(path, method)
-      : currentNode.findVersionChild(version, path, method)
+    var node = currentNode.findMatchingChild(constraintsExtractor, path, method)
 
     if (node === null) {
       node = currentNode.parametricBrother

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ if (!isRegexSafe(FULL_PATH_REGEXP)) {
   throw new Error('the FULL_PATH_REGEXP is not safe, update this module')
 }
 
-const acceptVersionStrategy = require('./lib/accept-version')
+const acceptConstraints = require('./lib/accept-constraints')
 
 function Router (opts) {
   if (!(this instanceof Router)) {
@@ -50,8 +50,8 @@ function Router (opts) {
   this.ignoreTrailingSlash = opts.ignoreTrailingSlash || false
   this.maxParamLength = opts.maxParamLength || 100
   this.allowUnsafeRegex = opts.allowUnsafeRegex || false
-  this.versioning = opts.versioning || acceptVersionStrategy
-  this.tree = new Node({ versions: this.versioning.storage() })
+  this.constraining = acceptConstraints(opts.constrainingStrategies)
+  this.tree = new Node({ constraints: this.constraining.storage() })
   this.routes = []
 }
 

--- a/index.js
+++ b/index.js
@@ -352,14 +352,14 @@ Router.prototype.off = function off (method, path) {
 }
 
 Router.prototype.lookup = function lookup (req, res, ctx) {
-  var handle = this.find(req.method, sanitizeUrl(req.url), this.versioning.deriveVersion(req, ctx))
+  var handle = this.find(req.method, sanitizeUrl(req.url), this.constraining.getConstraintsExtractor(req, ctx))
   if (handle === null) return this._defaultRoute(req, res, ctx)
   return ctx === undefined
     ? handle.handler(req, res, handle.params, handle.store)
     : handle.handler.call(ctx, req, res, handle.params, handle.store)
 }
 
-Router.prototype.find = function find (method, path, version) {
+Router.prototype.find = function find (method, path, constraintsExtractor) {
   if (path.charCodeAt(0) !== 47) { // 47 is '/'
     path = path.replace(FULL_PATH_REGEXP, '/')
   }

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
     assert(typeof opts.constraints === 'object' && opts.constraints !== null, 'Constraints should be an object')
     if (Object.keys(opts.constraints).length === 0) {
       opts.constraints = undefined
-  }
+    }
   }
 
   const params = []
@@ -242,9 +242,9 @@ Router.prototype._insert = function _insert (method, path, kind, params, handler
       // if the longest common prefix has the same length of the current path
       // the handler should be added to the current node, to a child otherwise
       if (len === pathLen) {
-        if (version) {
-          assert(!currentNode.getVersionHandler(version, method), `Method '${method}' already declared for route '${route}' version '${version}'`)
-          currentNode.setVersionHandler(version, method, handler, params, store)
+        if (constraints) {
+          assert(!currentNode.getConstraintsHandler(constraints, method), `Method '${method}' already declared for route '${route}' with constraints '${JSON.stringify(constraints)}'`)
+          currentNode.setConstraintsHandler(constraints, method, handler, params, store)
         } else {
           assert(!currentNode.getHandler(method), `Method '${method}' already declared for route '${route}'`)
           currentNode.setHandler(method, handler, params, store)
@@ -258,8 +258,8 @@ Router.prototype._insert = function _insert (method, path, kind, params, handler
           regex: regex,
           constraints: this.constraining.storage()
         })
-        if (version) {
-          node.setVersionHandler(version, method, handler, params, store)
+        if (constraints) {
+          node.setConstraintsHandler(constraints, method, handler, params, store)
         } else {
           node.setHandler(method, handler, params, store)
         }
@@ -280,6 +280,8 @@ Router.prototype._insert = function _insert (method, path, kind, params, handler
       }
       // there are not children within the given label, let's create a new one!
       node = new Node({ prefix: path, kind: kind, handlers: null, regex: regex, constraints: this.constraining.storage() })
+      if (constraints) {
+        node.setConstraintsHandler(constraints, method, handler, params, store)
       } else {
         node.setHandler(method, handler, params, store)
       }
@@ -288,9 +290,9 @@ Router.prototype._insert = function _insert (method, path, kind, params, handler
 
     // the node already exist
     } else if (handler) {
-      if (version) {
-        assert(!currentNode.getVersionHandler(version, method), `Method '${method}' already declared for route '${route}' version '${version}'`)
-        currentNode.setVersionHandler(version, method, handler, params, store)
+      if (constraints) {
+        assert(!currentNode.getConstraintsHandler(constraints, method), `Method '${method}' already declared for route '${route}' with constraints '${JSON.stringify(constraints)}'`)
+        currentNode.setConstraintsHandler(constraints, method, handler, params, store)
       } else {
         assert(!currentNode.getHandler(method), `Method '${method}' already declared for route '${route}'`)
         currentNode.setHandler(method, handler, params, store)

--- a/lib/accept-constraints.js
+++ b/lib/accept-constraints.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const ConstraintsStore = require('./constraints-store')
+
+const acceptVersionStrategy = require('./strategies/accept-version')
+const acceptHostStrategy = require('./strategies/accept-host')
+
+module.exports = (strats) => {
+  const strategies = {
+    version: acceptVersionStrategy,
+    host: acceptHostStrategy,
+    ...strats
+  }
+
+  return {
+    storage: ConstraintsStore.bind(null, instanciateStorage()),
+    getConstraintsExtractor: function (req, ctx) {
+      return function (kConstraints) {
+        const derivedConstraints = {}
+        kConstraints.forEach(key => {
+          var value = strategies[key].deriveConstraint(req, ctx)
+          if (value) derivedConstraints[key] = value
+        })
+        return derivedConstraints
+      }
+    }
+  }
+
+  function instanciateStorage () {
+    const result = {}
+    Object.keys(strategies).forEach(strategy => {
+      result[strategy] = strategies[strategy].storage()
+    })
+    return result
+  }
+}

--- a/lib/constraints-store.js
+++ b/lib/constraints-store.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const { assert } = require('console')
+
+function ConstraintsStore (strategies) {
+  if (!(this instanceof ConstraintsStore)) {
+    return new ConstraintsStore(strategies)
+  }
+
+  this.strategies = strategies
+}
+
+ConstraintsStore.prototype.set = function (constraints, store) {
+  // TODO: Should I check for existence of at least one constraint?
+  if (typeof constraints !== 'object' || constraints === null) {
+    throw new TypeError('Constraints should be an object')
+  }
+
+  Object.keys(constraints).forEach(kConstraint => {
+    assert(this.strategies[kConstraint] !== null, `No strategy available for handling the constraint '${kConstraint}'`)
+    this.strategies[kConstraint].set(constraints[kConstraint], { store, constraints })
+  })
+
+  return this
+}
+
+ConstraintsStore.prototype.get = function (constraints, method) {
+  if (typeof constraints !== 'object' || constraints === null) {
+    throw new TypeError('Constraints should be an object')
+  }
+
+  var returnedStore = null
+  const keys = Object.keys(constraints)
+  for (var i = 0; i < keys.length; i++) {
+    const kConstraint = keys[i]
+    assert(this.strategies[kConstraint] !== null, `No strategy available for handling the constraint '${kConstraint}'`)
+    const storedObject = this.strategies[kConstraint].get(constraints[kConstraint])
+    if (!storedObject || !storedObject.store || !storedObject.store[method]) return null
+    // TODO: Order of properties may result in inequality
+    if (JSON.stringify(constraints) !== JSON.stringify(storedObject.constraints)) return null
+    if (!returnedStore) returnedStore = storedObject.store
+  }
+
+  return returnedStore
+}
+
+module.exports = ConstraintsStore

--- a/lib/strategies/accept-host.js
+++ b/lib/strategies/accept-host.js
@@ -1,0 +1,17 @@
+'use strict'
+
+// TODO: Add regex support
+module.exports = {
+  storage: function () {
+    let hosts = {}
+    return {
+      get: (host) => { return hosts[host] || null },
+      set: (host, store) => { hosts[host] = store },
+      del: (host) => { delete hosts[host] },
+      empty: () => { hosts = {} }
+    }
+  },
+  deriveConstraint: function (req, ctx) {
+    return req.headers.host
+  }
+}

--- a/lib/strategies/accept-version.js
+++ b/lib/strategies/accept-version.js
@@ -4,7 +4,7 @@ const SemVerStore = require('semver-store')
 
 module.exports = {
   storage: SemVerStore,
-  deriveVersion: function (req, ctx) {
+  deriveConstraint: function (req, ctx) {
     return req.headers['accept-version']
   }
 }

--- a/node.js
+++ b/node.js
@@ -197,8 +197,8 @@ Node.prototype.getHandler = function (method) {
   return this.handlers[method]
 }
 
-Node.prototype.getVersionHandler = function (version, method) {
-  var handlers = this.versions.get(version)
+Node.prototype.getConstraintsHandler = function (constraints, method) {
+  var handlers = this.constraintsStorage.get(constraints, method)
   return handlers === null ? handlers : handlers[method]
 }
 

--- a/node.js
+++ b/node.js
@@ -164,7 +164,7 @@ Node.prototype.setHandler = function (method, handler, params, store) {
 
   assert(
     this.handlers[method] !== undefined,
-    `There is already an handler with method '${method}'`
+    `There is already a handler with method '${method}'`
   )
 
   this.handlers[method] = {

--- a/node.js
+++ b/node.js
@@ -13,8 +13,8 @@ const types = {
   MULTI_PARAM: 4
 }
 
-function Node (options) {
-  // former arguments order: prefix, children, kind, handlers, regex, versions
+function Node(options) {
+  // former arguments order: prefix, children, kind, handlers, regex, constraints
   options = options || {}
   this.prefix = options.prefix || '/'
   this.label = this.prefix[0]
@@ -26,6 +26,7 @@ function Node (options) {
   this.wildcardChild = null
   this.parametricBrother = null
   this.versions = options.versions
+  this.constraintsStorage = options.constraints
 }
 
 Object.defineProperty(Node.prototype, 'types', {

--- a/node.js
+++ b/node.js
@@ -117,42 +117,21 @@ Node.prototype.findByLabel = function (path) {
   return this.children[path[0]]
 }
 
-Node.prototype.findChild = function (path, method) {
+Node.prototype.findMatchingChild = function (constraintsExtractor, path, method) {
   var child = this.children[path[0]]
-  if (child !== undefined && (child.numberOfChildren > 0 || child.handlers[method] !== null)) {
+  if (child !== undefined && (child.numberOfChildren > 0 || child.getMatchingHandler(constraintsExtractor, method) !== null)) {
     if (path.slice(0, child.prefix.length) === child.prefix) {
       return child
     }
   }
 
   child = this.children[':']
-  if (child !== undefined && (child.numberOfChildren > 0 || child.handlers[method] !== null)) {
+  if (child !== undefined && (child.numberOfChildren > 0 || child.getMatchingHandler(constraintsExtractor, method) !== null)) {
     return child
   }
 
   child = this.children['*']
-  if (child !== undefined && (child.numberOfChildren > 0 || child.handlers[method] !== null)) {
-    return child
-  }
-
-  return null
-}
-
-Node.prototype.findVersionChild = function (version, path, method) {
-  var child = this.children[path[0]]
-  if (child !== undefined && (child.numberOfChildren > 0 || child.getVersionHandler(version, method) !== null)) {
-    if (path.slice(0, child.prefix.length) === child.prefix) {
-      return child
-    }
-  }
-
-  child = this.children[':']
-  if (child !== undefined && (child.numberOfChildren > 0 || child.getVersionHandler(version, method) !== null)) {
-    return child
-  }
-
-  child = this.children['*']
-  if (child !== undefined && (child.numberOfChildren > 0 || child.getVersionHandler(version, method) !== null)) {
+  if (child !== undefined && (child.numberOfChildren > 0 || child.getMatchingHandler(constraintsExtractor, method) !== null)) {
     return child
   }
 

--- a/node.js
+++ b/node.js
@@ -154,14 +154,15 @@ Node.prototype.setHandler = function (method, handler, params, store) {
   }
 }
 
-Node.prototype.setVersionHandler = function (version, method, handler, params, store) {
+Node.prototype.setConstraintsHandler = function (constraints, method, handler, params, store) {
   if (!handler) return
 
-  const handlers = this.versions.get(version) || new Handlers()
-  assert(
-    handlers[method] === null,
-    `There is already an handler with version '${version}' and method '${method}'`
-  )
+  const handlers = this.constraintsStorage.get(constraints, method) || new Handlers()
+
+  assert(handlers[method] === null, `There is already a handler with constraints '${JSON.stringify(constraints)}' and method '${method}'`)
+
+  // Update kConstraints with new constraint keys for this node
+  Object.keys(constraints).forEach(kConstraint => this.kConstraints.add(kConstraint))
 
   handlers[method] = {
     handler: handler,
@@ -169,7 +170,8 @@ Node.prototype.setVersionHandler = function (version, method, handler, params, s
     store: store || null,
     paramsLength: params.length
   }
-  this.versions.set(version, handlers)
+
+  this.constraintsStorage.set(constraints, handlers)
 }
 
 Node.prototype.getHandler = function (method) {

--- a/node.js
+++ b/node.js
@@ -25,7 +25,8 @@ function Node(options) {
   this.regex = options.regex || null
   this.wildcardChild = null
   this.parametricBrother = null
-  this.versions = options.versions
+  // kConstraints allows us to know which constraints we need to extract from the request
+  this.kConstraints = new Set()
   this.constraintsStorage = options.constraints
 }
 
@@ -99,7 +100,7 @@ Node.prototype.addChild = function (node) {
   return this
 }
 
-Node.prototype.reset = function (prefix, versions) {
+Node.prototype.reset = function (prefix, constraints) {
   this.prefix = prefix
   this.children = {}
   this.kind = this.types.STATIC
@@ -107,7 +108,8 @@ Node.prototype.reset = function (prefix, versions) {
   this.numberOfChildren = 0
   this.regex = null
   this.wildcardChild = null
-  this.versions = versions
+  this.kConstraints = new Set()
+  this.constraintsStorage = constraints
   return this
 }
 

--- a/node.js
+++ b/node.js
@@ -202,6 +202,17 @@ Node.prototype.getConstraintsHandler = function (constraints, method) {
   return handlers === null ? handlers : handlers[method]
 }
 
+Node.prototype.getMatchingHandler = function (constraintsExtractor, method) {
+  var constraints = constraintsExtractor(this.kConstraints)
+
+  if (Object.keys(constraints).length) {
+    var handler = this.getConstraintsHandler(constraints, method)
+    if (handler) return handler;
+  }
+
+  return this.getHandler(method)
+}
+
 Node.prototype.prettyPrint = function (prefix, tail) {
   var paramName = ''
   var handlers = this.handlers || {}


### PR DESCRIPTION
This PR is to add support for request based constraints, following the discussions in issues [fastify#2498](https://github.com/fastify/fastify/issues/2498) and [find-my-way#165](https://github.com/delvedor/find-my-way/issues/165)

Please note that this is still a WIP and tests are failing, but I'd like to start a discussion and get some feedback and direction.

## 01. API updates:

### a. Constructor:

Instead of `opts.versioning` that allows specifying the versioning strategy, the constructor now takes `opts.constrainingStrategies` that allows the user to override default strategies with custom ones.

The strategy object maintains the same structure as previously, with a single change of `deriveVersion` to `deriveConstraint` to be more generic.

The default strategies supported are `version` and `host`.

Right now host only supports exact match

### b. Route registration (.on):

When registering a route, the user can provide a `constraints` property in the `opts` parameter, this property is a flat object containing key-values constraints:

```jsx
{
	version: '1.0.0',
	host: 'auth.airhorns.dev'
}
```

### c. Routing (.find):

When finding a route, the find method now expects a function `constraintsExtractor` instead of a constraints object.

In the current codebase the use of versioned routes storage is only done if `deriveVersion` returns a non empty value.

This works well for the version constraint, which has to be explicitly set in the `accept-version` header. For other constraints like the header `host` it will always contain a value, which would imply the constrained storage will always be used.

In order to avoid that, the new solution that would support all use cases needs to derive the constraints for each tree node we check, since each node knows which constraints it supports.

The `constraintsExtractor` method expects a list of constraint keys that should be extracted from the request.

## 02. Internals:

Internally, these are some of the main changes that were made:

### a. accept-constraints:

Function that takes an optional strategies object, allowing the user to override/extend the existing strategies. Returns an object that allows creating instances of the `ConstraintsStore` bound to the available strategies via the `storage` property, and `getConstraintsExtractor` function that returns a `constraintsExtractor` function with access to the request object.

### b. constraints-store:

An instance of the `ConstraintsStore` is created for each node, it takes a list of strategies that it should use, where each strategy has its own storage:

`ConstraintsStore` exposes 2 methods:

- **set(constraints, store)**: Given a constraints object, we loop through its properties and call the appropriate strategy's **set()** method. We store the constraints object as well, which we'll need in the .get() method:

https://github.com/AyoubElk/find-my-way/blob/edd00c98f5eaaad5fd6f09b7ac645e3d2ab8d9bf/lib/constraints-store.js#L19-L22

- **get(constraints, method)**: Given a constraints object, calling the get method will result in a call to the get method of all the supported strategies. Since the strategies store handlers independently, if one of them returns `null` then we can know that no match that fulfills all constraints is found and we return `null`, otherwise we return the stored handlers.

https://github.com/AyoubElk/find-my-way/blob/edd00c98f5eaaad5fd6f09b7ac645e3d2ab8d9bf/lib/constraints-store.js#L38

    We also compare the given constraints object with the one we stored previously, but there seems to be an edge case here that I haven't considered before writing this.

https://github.com/AyoubElk/find-my-way/blob/edd00c98f5eaaad5fd6f09b7ac645e3d2ab8d9bf/lib/constraints-store.js#L39-L40

    Consider these routes:

    ```jsx
    router.on('GET', '/users', { constraints: { version: '1.0.0' } }, handler)
    router.on('GET', '/users', { constraints: { host: 'auth.airhorns.dev' } }, handler)
    ```

    Should this scenario be possible? If so, and given a request that can match both, which one should be matched

### c. node:

The main changes here are two new methods and one new property:

- **kConstraints**: A set that contains the constraint keys applicable to this node. But given the edge case mentioned above, it would be better to have an extra property that stores an array of constraints and try to match starting from the most to the least restricted routes. What do you think?
- **getMatchingHandler(constraintsExtractor, method)**: Extracts the applicable constraints from the req object if any, and calls `getConstraintsHandler()`, if no matching handler is found it calls `getHandler()` as well in case we have a non-constrained route available.
- **findMatchingChild(constraintsExtractor, path, method)**: replaces both `findChild()` and `findVersionChild()`



Looking forward to hearing your thoughts!