### PR TITLE
Support optional parameters at the end of the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ router.on('GET', '/example/at/:hour(^\\d{2})h:minute(^\\d{2})m', (req, res, para
 ```
 In this case as parameter separator it's possible to use whatever character is not matched by the regular expression.
 
+The last parameter can be made optional if you add a question mark ("?") at the end of the parameters name.
+```js
+router.on('GET', '/example/posts/:id?', (req, res, params) => {}))
+```
+In this case you can request `/example/posts` as well as `/example/posts/1`. The optional param will be undefined if not specified.
+
 Having a route with multiple parameters may affect negatively the performance, so prefer single parameter approach whenever possible, especially on routes which are on the hot path of your application.
 
 <a name="match-order"></a>

--- a/index.js
+++ b/index.js
@@ -70,6 +70,17 @@ Router.prototype.on = function on (method, path, opts, handler, store) {
   // handler validation
   assert(typeof handler === 'function', 'Handler should be a function')
 
+  // path ends with optional parameter
+  if (path.endsWith('?') || path.endsWith('?/')) {
+    const optionalParamRegex = /(\/:[^/]*?)\?(\/?)$/
+    const pathFull = path.replace(optionalParamRegex, '$1')
+    const pathOptional = path.replace(optionalParamRegex, '$2')
+
+    this.on(method, pathFull, opts, handler, store)
+    this.on(method, pathOptional, opts, handler, store)
+    return
+  }
+
   this._on(method, path, opts, handler, store)
 
   if (this.ignoreTrailingSlash && path !== '/' && !path.endsWith('*')) {

--- a/index.js
+++ b/index.js
@@ -331,6 +331,17 @@ Router.prototype.off = function off (method, path) {
   assert(path.length > 0, 'The path could not be empty')
   assert(path[0] === '/' || path[0] === '*', 'The first character of a path should be `/` or `*`')
 
+  // path ends with optional parameter
+  const optionalParamRegex = /(\/:[^/]*?)\?(\/?)$/
+  if (path.match(optionalParamRegex)) {
+    const pathFull = path.replace(optionalParamRegex, '$1$2')
+    const pathOptional = path.replace(optionalParamRegex, '$2')
+
+    this.off(method, pathFull)
+    this.off(method, pathOptional)
+    return
+  }
+
   // Rebuild tree without the specific route
   const ignoreTrailingSlash = this.ignoreTrailingSlash
   var newRoutes = self.routes.filter(function (route) {

--- a/index.js
+++ b/index.js
@@ -71,8 +71,8 @@ Router.prototype.on = function on (method, path, opts, handler, store) {
   assert(typeof handler === 'function', 'Handler should be a function')
 
   // path ends with optional parameter
-  if (path.endsWith('?') || path.endsWith('?/')) {
-    const optionalParamRegex = /(\/:[^/]*?)\?(\/?)$/
+  const optionalParamRegex = /(\/:[^/]*?)\?(\/?)$/
+  if (path.match(optionalParamRegex)) {
     const pathFull = path.replace(optionalParamRegex, '$1$2')
     const pathOptional = path.replace(optionalParamRegex, '$2')
 

--- a/index.js
+++ b/index.js
@@ -19,9 +19,14 @@ const Node = require('./node')
 const NODE_TYPES = Node.prototype.types
 const httpMethods = http.METHODS
 const FULL_PATH_REGEXP = /^https?:\/\/.*?\//
+const OPTIONAL_PARAM_REGEXP = /(\/:[^/()]*?)\?(\/?)/
 
 if (!isRegexSafe(FULL_PATH_REGEXP)) {
   throw new Error('the FULL_PATH_REGEXP is not safe, update this module')
+}
+
+if (!isRegexSafe(OPTIONAL_PARAM_REGEXP)) {
+  throw new Error('the OPTIONAL_PARAM_REGEXP is not safe, update this module')
 }
 
 const acceptVersionStrategy = require('./lib/accept-version')
@@ -71,10 +76,12 @@ Router.prototype.on = function on (method, path, opts, handler, store) {
   assert(typeof handler === 'function', 'Handler should be a function')
 
   // path ends with optional parameter
-  const optionalParamRegex = /(\/:[^/]*?)\?(\/?)$/
-  if (path.match(optionalParamRegex)) {
-    const pathFull = path.replace(optionalParamRegex, '$1$2')
-    const pathOptional = path.replace(optionalParamRegex, '$2')
+  const optionalParamMatch = path.match(OPTIONAL_PARAM_REGEXP)
+  if (optionalParamMatch) {
+    assert(path.length === optionalParamMatch.index + optionalParamMatch[0].length, 'Optional Parameter needs to be the last parameter of the path')
+
+    const pathFull = path.replace(OPTIONAL_PARAM_REGEXP, '$1$2')
+    const pathOptional = path.replace(OPTIONAL_PARAM_REGEXP, '$2')
 
     this.on(method, pathFull, opts, handler, store)
     this.on(method, pathOptional, opts, handler, store)
@@ -332,10 +339,12 @@ Router.prototype.off = function off (method, path) {
   assert(path[0] === '/' || path[0] === '*', 'The first character of a path should be `/` or `*`')
 
   // path ends with optional parameter
-  const optionalParamRegex = /(\/:[^/]*?)\?(\/?)$/
-  if (path.match(optionalParamRegex)) {
-    const pathFull = path.replace(optionalParamRegex, '$1$2')
-    const pathOptional = path.replace(optionalParamRegex, '$2')
+  const optionalParamMatch = path.match(OPTIONAL_PARAM_REGEXP)
+  if (optionalParamMatch) {
+    assert(path.length === optionalParamMatch.index + optionalParamMatch[0].length, 'Optional Parameter needs to be the last parameter of the path')
+
+    const pathFull = path.replace(OPTIONAL_PARAM_REGEXP, '$1$2')
+    const pathOptional = path.replace(OPTIONAL_PARAM_REGEXP, '$2')
 
     this.off(method, pathFull)
     this.off(method, pathOptional)

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ Router.prototype.on = function on (method, path, opts, handler, store) {
   // path ends with optional parameter
   if (path.endsWith('?') || path.endsWith('?/')) {
     const optionalParamRegex = /(\/:[^/]*?)\?(\/?)$/
-    const pathFull = path.replace(optionalParamRegex, '$1')
+    const pathFull = path.replace(optionalParamRegex, '$1$2')
     const pathOptional = path.replace(optionalParamRegex, '$2')
 
     this.on(method, pathFull, opts, handler, store)

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -74,7 +74,6 @@ test('Multi parametric route with optional param', (t) => {
   })
 
   findMyWay.lookup({ method: 'GET', url: '/a/foo-bar-baz', headers: {} }, null)
-  // findMyWay.lookup({ method: 'GET', url: '/a/foo', headers: {} }, null)
   findMyWay.lookup({ method: 'GET', url: '/a', headers: {} }, null)
 })
 

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+
+test('Test route with optional parameter', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/a/:param/b/:optional?', (req, res, params) => {
+    if (params.optional) {
+      t.equal(params.optional, 'foo')
+    } else {
+      t.equal(params.optional, undefined)
+    }
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/a/foo-bar/b', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/a/foo-bar/b/foo', headers: {} }, null)
+})

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -67,7 +67,6 @@ test('Multi parametric route with optional param', (t) => {
   })
 
   findMyWay.on('GET', '/a/:p1-:p2?', (req, res, params) => {
-    console.log('Multi parametric params', params)
     if (params.p1 && params.p2) {
       t.equal(params.p1, 'foo')
       t.equal(params.p2, 'bar-baz')
@@ -77,4 +76,23 @@ test('Multi parametric route with optional param', (t) => {
   findMyWay.lookup({ method: 'GET', url: '/a/foo-bar-baz', headers: {} }, null)
   // findMyWay.lookup({ method: 'GET', url: '/a/foo', headers: {} }, null)
   findMyWay.lookup({ method: 'GET', url: '/a', headers: {} }, null)
+})
+
+test('derigister a route with optional param', (t) => {
+  t.plan(4)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/a/:param/b/:optional?', (req, res, params) => {})
+
+  t.ok(findMyWay.find('GET', '/a/:param/b'))
+  t.ok(findMyWay.find('GET', '/a/:param/b/:optional'))
+
+  findMyWay.off('GET', '/a/:param/b/:optional?')
+
+  t.notOk(findMyWay.find('GET', '/a/:param/b'))
+  t.notOk(findMyWay.find('GET', '/a/:param/b/:optional'))
 })

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -57,3 +57,24 @@ test('Test for param with ? not at the end', (t) => {
 
   findMyWay.lookup({ method: 'GET', url: '/foo/a/baz', headers: {} }, null)
 })
+
+test('Multi parametric route with optional param', (t) => {
+  t.plan(2)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/a/:p1-:p2?', (req, res, params) => {
+    console.log('Multi parametric params', params)
+    if (params.p1 && params.p2) {
+      t.equal(params.p1, 'foo')
+      t.equal(params.p2, 'bar-baz')
+    }
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/a/foo-bar-baz', headers: {} }, null)
+  // findMyWay.lookup({ method: 'GET', url: '/a/foo', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/a', headers: {} }, null)
+})

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -86,7 +86,7 @@ test('Optional Parameter with ignoreTrailingSlash = true', (t) => {
     }
   })
 
-  findMyWay.on('GET', '/test/hello/:optional?/', (req, res, params) => {
+  findMyWay.on('GET', '/test/hello/:optional?', (req, res, params) => {
     if (params.optional) {
       t.equal(params.optional, 'foo')
     } else {
@@ -105,15 +105,16 @@ test('Optional Parameter with ignoreTrailingSlash = false', (t) => {
   const findMyWay = FindMyWay({
     ignoreTrailingSlash: false,
     defaultRoute: (req, res) => {
-      t.notMatch(req.url, '.*/$') // urls without trailing slash
+      t.match(req.url, '/test/hello/foo/')
     }
   })
 
-  findMyWay.on('GET', '/test/hello/:optional?/', (req, res, params) => {
+  findMyWay.on('GET', '/test/hello/:optional?', (req, res, params) => {
+    console.log('req', req, 'opt', params.optional)
     if (params.optional) {
       t.equal(params.optional, 'foo')
     } else {
-      t.equal(params.optional, undefined)
+      t.equal(params.optional, req.url === '/test/hello/' ? '' : undefined)
     }
   })
 

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -78,6 +78,52 @@ test('Multi parametric route with optional param', (t) => {
   findMyWay.lookup({ method: 'GET', url: '/a', headers: {} }, null)
 })
 
+test('Optional Parameter with ignoreTrailingSlash = true', (t) => {
+  t.plan(4)
+  const findMyWay = FindMyWay({
+    ignoreTrailingSlash: true,
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/test/hello/:optional?/', (req, res, params) => {
+    if (params.optional) {
+      t.equal(params.optional, 'foo')
+    } else {
+      t.equal(params.optional, undefined)
+    }
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/foo', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/foo/', headers: {} }, null)
+})
+
+test('Optional Parameter with ignoreTrailingSlash = false', (t) => {
+  t.plan(4)
+  const findMyWay = FindMyWay({
+    ignoreTrailingSlash: false,
+    defaultRoute: (req, res) => {
+      t.notMatch(req.url, '.*/$') // urls without trailing slash
+    }
+  })
+
+  findMyWay.on('GET', '/test/hello/:optional?/', (req, res, params) => {
+    if (params.optional) {
+      t.equal(params.optional, 'foo')
+    } else {
+      t.equal(params.optional, undefined)
+    }
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/foo', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/foo/', headers: {} }, null)
+})
+
 test('derigister a route with optional param', (t) => {
   t.plan(4)
   const findMyWay = FindMyWay({

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -50,12 +50,12 @@ test('Test for param with ? not at the end', (t) => {
     }
   })
 
-  findMyWay.on('GET', '/foo/:bar?/baz', (req, res, params) => {
-    // since we only support optional params at the end of the path, 'bar?' is our param name
-    t.equal(params['bar?'], 'a')
-  })
-
-  findMyWay.lookup({ method: 'GET', url: '/foo/a/baz', headers: {} }, null)
+  try {
+    findMyWay.on('GET', '/foo/:bar?/baz', (req, res, params) => {})
+    t.fail('Optional Param in the middle of the path is not allowed')
+  } catch (e) {
+    t.is(e.message, 'Optional Parameter needs to be the last parameter of the path')
+  }
 })
 
 test('Multi parametric route with optional param', (t) => {

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -4,7 +4,7 @@ const t = require('tap')
 const test = t.test
 const FindMyWay = require('../')
 
-test('Test route with optional parameter', t => {
+test('Test route with optional parameter', (t) => {
   t.plan(2)
   const findMyWay = FindMyWay({
     defaultRoute: (req, res) => {
@@ -22,4 +22,38 @@ test('Test route with optional parameter', t => {
 
   findMyWay.lookup({ method: 'GET', url: '/a/foo-bar/b', headers: {} }, null)
   findMyWay.lookup({ method: 'GET', url: '/a/foo-bar/b/foo', headers: {} }, null)
+})
+
+test('Test for duplicate route with optional param', (t) => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/foo/:bar?', (req, res, params) => {})
+
+  try {
+    findMyWay.on('GET', '/foo', (req, res, params) => {})
+    t.fail('method is already declared for route with optional param')
+  } catch (e) {
+    t.is(e.message, 'Method \'GET\' already declared for route \'/foo\'')
+  }
+})
+
+test('Test for param with ? not at the end', (t) => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/foo/:bar?/baz', (req, res, params) => {
+    // since we only support optional params at the end of the path, 'bar?' is our param name
+    t.equal(params['bar?'], 'a')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/foo/a/baz', headers: {} }, null)
 })


### PR DESCRIPTION
Originally wanted to add this feature to fastify: https://github.com/fastify/fastify/pull/2607 but we came to the conclusion that it fits better into here.

Support optional parameters (with a '?' suffix) if they are at the end of the path.

Example: 
**Input Route:** `/v1/user/:userId/admin/mail/:id?`
Can be accessed by:

1. `/v1/user/:userId/admin/mail/:id`
2. `/v1/user/:userId/admin/mail`

More information about the regex:
<img width="1592" alt="Screen Shot 2020-10-14 at 16 17 07" src="https://user-images.githubusercontent.com/3339615/96002228-2b75d780-0e39-11eb-8fa2-dfcc85b62ab4.png">

<img width="1599" alt="Screen Shot 2020-10-14 at 16 17 21" src="https://user-images.githubusercontent.com/3339615/96002207-287ae700-0e39-11eb-8d54-fbb42e1799eb.png">
So the trailing slash is still preserved with the second capture group.
