### PR TITLE
Switch to using one tree per method instead of a map

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -17,10 +17,31 @@ const findMyWay = new FindMyWay()
 findMyWay.on('GET', '/', () => true)
 findMyWay.on('GET', '/user/:id', () => true)
 findMyWay.on('GET', '/user/:id/static', () => true)
+findMyWay.on('POST', '/user/:id', () => true)
+findMyWay.on('PUT', '/user/:id', () => true)
 findMyWay.on('GET', '/customer/:name-:surname', () => true)
+findMyWay.on('POST', '/customer', () => true)
 findMyWay.on('GET', '/at/:hour(^\\d+)h:minute(^\\d+)m', () => true)
 findMyWay.on('GET', '/abc/def/ghi/lmn/opq/rst/uvz', () => true)
 findMyWay.on('GET', '/', { version: '1.2.0' }, () => true)
+
+findMyWay.on('GET', '/products', () => true)
+findMyWay.on('GET', '/products/:id', () => true)
+findMyWay.on('GET', '/products/:id/options', () => true)
+
+findMyWay.on('GET', '/posts', () => true)
+findMyWay.on('POST', '/posts', () => true)
+findMyWay.on('GET', '/posts/:id', () => true)
+findMyWay.on('GET', '/posts/:id/author', () => true)
+findMyWay.on('GET', '/posts/:id/comments', () => true)
+findMyWay.on('POST', '/posts/:id/comments', () => true)
+findMyWay.on('GET', '/posts/:id/comments/:id', () => true)
+findMyWay.on('GET', '/posts/:id/comments/:id/author', () => true)
+findMyWay.on('GET', '/posts/:id/counter', () => true)
+
+findMyWay.on('GET', '/pages', () => true)
+findMyWay.on('POST', '/pages', () => true)
+findMyWay.on('GET', '/pages/:id', () => true)
 
 suite
   .add('lookup static route', function () {
@@ -64,6 +85,12 @@ suite
   })
   .add('find static versioned route', function () {
     findMyWay.find('GET', '/', '1.x')
+  })
+  .add('find long nested dynamic route', function () {
+    findMyWay.find('GET', '/posts/10/comments/42/author', undefined)
+  })
+  .add('find long nested dynamic route with other method', function () {
+    findMyWay.find('POST', '/posts/10/comments', undefined)
   })
   .on('cycle', function (event) {
     console.log(String(event.target))

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -1,0 +1,83 @@
+function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
+  var paramName = ''
+  var methods = new Set(flattenedNode.nodes.map(node => node.method))
+
+  if (flattenedNode.prefix.includes(':')) {
+    flattenedNode.nodes.forEach((node, index) => {
+      var params = node.handler.params
+      var param = params[params.length - 1]
+      if (methods.size > 1) {
+        if (index === 0) {
+          paramName += param + ` (${node.method})\n`
+          return
+        }
+        paramName += prefix + '    :' + param + ` (${node.method})`
+        paramName += (index === methods.size - 1 ? '' : '\n')
+      } else {
+        paramName = params[params.length - 1] + ` (${node.method})`
+      }
+    })
+  } else if (methods.size) {
+    paramName = ` (${Array.from(methods).join('|')})`
+  }
+
+  var tree = `${prefix}${tail ? '└── ' : '├── '}${flattenedNode.prefix}${paramName}\n`
+
+  prefix = `${prefix}${tail ? '    ' : '│   '}`
+  const labels = Object.keys(flattenedNode.children)
+  for (var i = 0; i < labels.length; i++) {
+    const child = flattenedNode.children[labels[i]]
+    tree += prettyPrintFlattenedNode(child, prefix, i === (labels.length - 1))
+  }
+  return tree
+}
+
+function flattenNode (flattened, node) {
+  if (node.handler) {
+    flattened.nodes.push(node)
+  }
+
+  if (node.children) {
+    for (const child of Object.values(node.children)) {
+      const childPrefixSegments = child.prefix.split(/(?=\/)/) // split on the slash separator but use a regex to lookahead and not actually match it, preserving it in the returned string segments
+      let cursor = flattened
+      let parent
+      for (const segment of childPrefixSegments) {
+        parent = cursor
+        cursor = cursor.children[segment]
+        if (!cursor) {
+          cursor = {
+            prefix: segment,
+            nodes: [],
+            children: {}
+          }
+          parent.children[segment] = cursor
+        }
+      }
+
+      flattenNode(cursor, child)
+    }
+  }
+}
+
+function compressFlattenedNode (flattenedNode) {
+  const childKeys = Object.keys(flattenedNode.children)
+  if (flattenedNode.nodes.length === 0 && childKeys.length === 1) {
+    const child = flattenedNode.children[childKeys[0]]
+    if (child.nodes.length <= 1) {
+      compressFlattenedNode(child)
+      flattenedNode.nodes = child.nodes
+      flattenedNode.prefix += child.prefix
+      flattenedNode.children = child.children
+      return flattenedNode
+    }
+  }
+
+  for (const key of Object.keys(flattenedNode.children)) {
+    compressFlattenedNode(flattenedNode.children[key])
+  }
+
+  return flattenedNode
+}
+
+module.exports = { flattenNode, compressFlattenedNode, prettyPrintFlattenedNode }

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -36,10 +36,8 @@ test('pretty print - parametric routes', t => {
 
   const expected = `└── /
     ├── test (GET)
-    │   └── /
-    │       └── :hello (GET)
-    └── hello/
-        └── :world (GET)
+    │   └── /:hello (GET)
+    └── hello/:world (GET)
 `
 
   t.is(typeof tree, 'string')
@@ -57,12 +55,11 @@ test('pretty print - mixed parametric routes', t => {
 
   const tree = findMyWay.prettyPrint()
 
-  const expected = `└── /
-    └── test (GET)
-        └── /
-            └── :hello (GET)
-                :hello (POST)
-                └── /world (GET)
+  const expected = `└── /test (GET)
+    └── /
+        └── :hello (GET)
+            :hello (POST)
+            └── /world (GET)
 `
 
   t.is(typeof tree, 'string')
@@ -81,10 +78,8 @@ test('pretty print - wildcard routes', t => {
 
   const expected = `└── /
     ├── test (GET)
-    │   └── /
-    │       └── * (GET)
-    └── hello/
-        └── * (GET)
+    │   └── /* (GET)
+    └── hello/* (GET)
 `
 
   t.is(typeof tree, 'string')
@@ -102,13 +97,12 @@ test('pretty print - parametric routes with same parent and followed by a static
 
   const tree = findMyWay.prettyPrint()
 
-  const expected = `└── /
-    └── test (GET)
-        └── /hello
-            ├── /
-            │   └── :id (GET)
-            │       :id (POST)
-            └── world (GET)
+  const expected = `└── /test (GET)
+    └── /hello
+        ├── /
+        │   └── :id (GET)
+        │       :id (POST)
+        └── world (GET)
 `
 
   t.is(typeof tree, 'string')


### PR DESCRIPTION
This makes pretty printing annoying, but increases performance!

With n trees instead of one tree, each tree is only split for handlers it actually has, so for HTTP verbs like POST or PUT that tend to have fewer routes, the trees are smaller and faster to traverse. For the HTTP GET tree, there are fewer nodes and I think better cache locality as that tree is traversed the most often. Each verb doesn't pay any traversal penalty for the other trees' size. This also results in more instances of more selective version stores, which means traversing them should be faster at the expense of a bit more memory consumption.

This also makes the constraints implementation (see #166) easier, and prevents bugs like #132, and avoids the extra checks we have to do to fix that bug.

This also prevents tree traversal for methods where there are no routes at all, which is a small optimization but kinda nice regardless.

For the pretty printing algorithm, I think a nice pretty print wouldn't be per method and would instead show all routes in the same list, so I added code to merge the separate node trees and then pretty print the merged tree! To make it look pretty I added some "compression" to the tree where branches that only had one branch get compressed down, which if you ask me results in some prettier output, see the tests.

| Test  | `master` | `one-tree-per-method` | 
| ------------- | ------------- |------|
lookup static route |  42,774,309 ops/sec ±0.84% (580 runs sampled) | 41,200,005 ops/sec ±0.98% (591 runs sampled)
lookup dynamic route | 3,536,084 ops/sec ±0.70% (587 runs sampled)    | 3,553,160 ops/sec ±0.28% (591 runs sampled)
lookup dynamic multi-parametric route | 1,842,343 ops/sec ±0.92% (587 runs sampled)   | 2,047,064 ops/sec ±0.83% (584 runs sampled)
lookup dynamic multi-parametric route with regex | 1,477,768 ops/sec ±0.57% (590 runs sampled)    | 1,500,267 ops/sec ±0.64% (590 runs sampled)
lookup long static route | 3,350,884 ops/sec ±0.62% (589 runs sampled)    | 3,406,235 ops/sec ±0.77% (588 runs sampled)
lookup long dynamic route | 2,491,556 ops/sec ±0.63% (585 runs sampled)  | 2,338,285 ops/sec ±1.60% (589 runs sampled)
lookup static versioned route | 9,241,735 ops/sec ±0.44% (586 runs sampled)  | 9,239,314 ops/sec ±0.40% (586 runs sampled)
find static route | 36,660,039 ops/sec ±0.76% (581 runs sampled)     | 35,230,842 ops/sec ±0.92% (578 runs sampled)
find dynamic route | 4,473,753 ops/sec ±0.72% (588 runs sampled)   | 4,469,776 ops/sec ±0.33% (590 runs sampled)
find dynamic multi-parametric route | 2,202,207 ops/sec ±1.00% (578 runs sampled)    | 2,237,214 ops/sec ±1.39% (585 runs sampled)
find dynamic multi-parametric route with regex | 1,680,101 ops/sec ±0.76% (579 runs sampled)  | 1,533,243 ops/sec ±1.04% (581 runs sampled)
find long static route | 4,633,069 ops/sec ±1.04% (588 runs sampled)   | 4,585,833 ops/sec ±0.51% (588 runs sampled)
find long dynamic route | 3,333,916 ops/sec ±0.76% (586 runs sampled)  | 3,491,155 ops/sec ±0.45% (589 runs sampled)
find static versioned route | 10,779,325 ops/sec ±0.73% (586 runs sampled)  | 10,801,810 ops/sec ±0.89% (580 runs sampled)
find long nested dynamic route | 1,379,726 ops/sec ±0.45% (587 runs sampled) | 1,418,610 ops/sec ±0.68% (588 runs sampled)
**find long nested dynamic route with other method** | **1,962,454 ops/sec ±0.97% (587 runs sampled)**   | **2,499,722 ops/sec ±0.38% (587 runs sampled)**

I split this out of the work I've been doing to complete the request constraints stuff from #166 . It hasn't changed routing behaviour at all, just the performance characteristics, so I don't think it needs a major release. The pretty print output has changed somewhat, but I'm not sure if that counts as a breaking change. 