### PR TITLE
Pretty print handler names

### DIFF
--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -1,25 +1,34 @@
 function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
   var paramName = ''
-  var methods = new Set(flattenedNode.nodes.map(node => node.method))
+  const handlers = flattenedNode.nodes.map(node => ({ method: node.method, ...node.handler }))
 
-  if (flattenedNode.prefix.includes(':')) {
-    flattenedNode.nodes.forEach((node, index) => {
-      var params = node.handler.params
-      var param = params[params.length - 1]
-      if (methods.size > 1) {
-        if (index === 0) {
-          paramName += param + ` (${node.method})\n`
-          return
-        }
-        paramName += prefix + '    :' + param + ` (${node.method})`
-        paramName += (index === methods.size - 1 ? '' : '\n')
-      } else {
-        paramName = params[params.length - 1] + ` (${node.method})`
+  handlers.forEach((handler, index) => {
+    let suffix = `(${handler.method}`
+    if (handler.handler && handler.handler.name.length > 0) {
+      suffix += ' ' + handler.handler.name
+    }
+    suffix += ')'
+
+    let name = ''
+    if (flattenedNode.prefix.includes(':')) {
+      var params = handler.params
+      name = params[params.length - 1]
+      if (index > 0) {
+        name = ':' + name
       }
-    })
-  } else if (methods.size) {
-    paramName = ` (${Array.from(methods).join('|')})`
-  }
+    } else if (index > 0) {
+      name = flattenedNode.prefix
+    }
+
+    if (index === 0) {
+      paramName += name + ` ${suffix}`
+      return
+    } else {
+      paramName += '\n'
+    }
+
+    paramName += prefix + '    ' + name + ` ${suffix}`
+  })
 
   var tree = `${prefix}${tail ? '└── ' : '├── '}${flattenedNode.prefix}${paramName}\n`
 

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -108,3 +108,26 @@ test('pretty print - parametric routes with same parent and followed by a static
   t.is(typeof tree, 'string')
   t.equal(tree, expected)
 })
+
+test('pretty print - parametric routes with named handlers', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+  findMyWay.on('GET', '/test', function testRoot () {})
+  findMyWay.on('GET', '/test/hello/:id', function getHello () {})
+  findMyWay.on('POST', '/test/hello/:id', function postHello () {})
+  findMyWay.on('GET', '/test/helloworld', function helloWorld () {})
+
+  const tree = findMyWay.prettyPrint()
+
+  const expected = `└── /test (GET testRoot)
+    └── /hello
+        ├── /
+        │   └── :id (GET getHello)
+        │       :id (POST postHello)
+        └── world (GET helloWorld)
+`
+
+  t.is(typeof tree, 'string')
+  t.equal(tree, expected)
+})


### PR DESCRIPTION
This replaces and closes #138, closes #144.

This adds a handler function's name to the pretty printed route output. It uses `Function.name`, so no new dependencies or anything.
 
Before:

```
└── /test (GET)
    └── /hello
        ├── /
        │   └── :id (GET)
        │       :id (POST)
        └── world (GET)
```

After:
```
└── /test (GET testRoot)
    └── /hello
        ├── /
        │   └── :id (GET getHello)
        │       :id (POST postHello)
        └── world (GET helloWorld)
```

It required a kind of annoying change in how the handlers are iterated to pretty print, but that change is also necessary for the constrained route handler work in #166 so it's one more thing that I peeled out for merging separately. 