### PR TITLE
feature: add setDefaultRoute method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,11 @@ declare namespace Router {
     store: any
   ) => void;
 
+  type DefaultRoute<V extends HTTPVersion> = (
+    req: Req<V>,
+    res: Res<V>,
+  ) => void;
+
   interface Config<V extends HTTPVersion> {
     ignoreTrailingSlash?: boolean;
 
@@ -66,10 +71,7 @@ declare namespace Router {
 
     maxParamLength?: number;
 
-    defaultRoute?(
-      req: Req<V>,
-      res: Res<V>
-    ): void;
+    defaultRoute?: DefaultRoute<V>;
 
     onBadUrl?(
       path: string,
@@ -144,6 +146,10 @@ declare namespace Router {
       path: string,
       version?: string
     ): FindResult<V> | null;
+
+    setDefaultRoute(
+      defaultRoute: DefaultRoute<V>,
+    ): void;
 
     reset(): void;
     prettyPrint(): string;

--- a/index.js
+++ b/index.js
@@ -33,12 +33,8 @@ function Router (opts) {
   }
   opts = opts || {}
 
-  if (opts.defaultRoute) {
-    assert(typeof opts.defaultRoute === 'function', 'The default route must be a function')
-    this.defaultRoute = opts.defaultRoute
-  } else {
-    this.defaultRoute = null
-  }
+  this.defaultRoute = null
+  this.setDefaultRoute(opts.defaultRoute)
 
   if (opts.onBadUrl) {
     assert(typeof opts.onBadUrl === 'function', 'The bad url handler must be a function')
@@ -585,6 +581,13 @@ Router.prototype._defaultRoute = function (req, res, ctx) {
   } else {
     res.statusCode = 404
     res.end()
+  }
+}
+
+Router.prototype.setDefaultRoute = function (defaultRoute) {
+  if (defaultRoute) {
+    assert(typeof defaultRoute === 'function', 'The default route must be a function')
+    this.defaultRoute = defaultRoute
   }
 }
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -91,6 +91,38 @@ test('default route', t => {
   })
 })
 
+test('default route is updated correctly', t => {
+  t.plan(3)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      res.statusCode = 404
+      res.end()
+    }
+  })
+
+  findMyWay.setDefaultRoute((req, res) => {
+    res.statusCode = 200
+    res.end()
+  })
+
+  const server = http.createServer((req, res) => {
+    findMyWay.lookup(req, res)
+  })
+
+  server.listen(0, err => {
+    t.error(err)
+    server.unref()
+
+    request({
+      method: 'GET',
+      uri: 'http://localhost:' + server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.strictEqual(response.statusCode, 200)
+    })
+  })
+})
+
 test('automatic default route', t => {
   t.plan(3)
   const findMyWay = FindMyWay()

--- a/test/types/router.test-d.ts
+++ b/test/types/router.test-d.ts
@@ -47,6 +47,7 @@ let http2Res!: Http2ServerResponse;
   expectType<void>(router.off(['GET', 'POST'], '/'))
 
   expectType<void>(router.lookup(http1Req, http1Res))
+  expectType<void>(router.setDefaultRoute((http1Req, http1Res) => {}))
   expectType<Router.FindResult<Router.HTTPVersion.V1> | null>(router.find('GET', '/'))
   expectType<Router.FindResult<Router.HTTPVersion.V1> | null>(router.find('GET', '/', '1.0.0'))
 
@@ -93,6 +94,7 @@ let http2Res!: Http2ServerResponse;
   expectType<void>(router.off(['GET', 'POST'], '/'))
 
   expectType<void>(router.lookup(http2Req, http2Res))
+  expectType<void>(router.setDefaultRoute((http2Req, http2Res) => {}))
   expectType<Router.FindResult<Router.HTTPVersion.V2> | null>(router.find('GET', '/'))
   expectType<Router.FindResult<Router.HTTPVersion.V2> | null>(router.find('GET', '/', '1.0.0'))
 


### PR DESCRIPTION
This change allows updating the `defaultRoute` method after the router instance is created.
It is needed [here](https://github.com/fastify/fastify/pull/2733) (relevant part of the discussion [here](https://github.com/fastify/fastify/pull/2733#pullrequestreview-550145862))