### PR TITLE
Pretty print bugfix and revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ router.find('GET', '/example', { host: 'fastify.io', version: '1.x' })
 ```
 
 <a name="pretty-print"></a>
-#### prettyPrint([{ commonPrefix: true }])
+#### prettyPrint([{ commonPrefix: false }])
 Prints the representation of the internal radix tree, useful for debugging.
 ```js
 findMyWay.on('GET', '/test', () => {})
@@ -430,7 +430,7 @@ console.log(findMyWay.prettyPrint())
 `prettyPrint` accepts an optional setting to use the internal routes array to render the tree.
 
 ```js
-console.log(findMyWay.prettyPrint({ commonPrefix: true }))
+console.log(findMyWay.prettyPrint({ commonPrefix: false }))
 // └── / (-)
 //     ├── test (GET)
 //     │   └── /hello (GET)

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ router.find('GET', '/example', { host: 'fastify.io', version: '1.x' })
 ```
 
 <a name="pretty-print"></a>
-#### prettyPrint([{ routesArray: true }])
+#### prettyPrint([{ commonPrefix: true }])
 Prints the representation of the internal radix tree, useful for debugging.
 ```js
 findMyWay.on('GET', '/test', () => {})
@@ -430,7 +430,7 @@ console.log(findMyWay.prettyPrint())
 `prettyPrint` accepts an optional setting to use the internal routes array to render the tree.
 
 ```js
-console.log(findMyWay.prettyPrint({ routesArray: true }))
+console.log(findMyWay.prettyPrint({ commonPrefix: true }))
 // └── / (-)
 //     ├── test (GET)
 //     │   └── /hello (GET)

--- a/README.md
+++ b/README.md
@@ -409,18 +409,34 @@ router.find('GET', '/example', { host: 'fastify.io', version: '1.x' })
 ```
 
 <a name="pretty-print"></a>
-#### prettyPrint()
+#### prettyPrint([{ routesArray: true }])
 Prints the representation of the internal radix tree, useful for debugging.
 ```js
 findMyWay.on('GET', '/test', () => {})
 findMyWay.on('GET', '/test/hello', () => {})
-findMyWay.on('GET', '/hello/world', () => {})
+findMyWay.on('GET', '/testing', () => {})
+findMyWay.on('GET', '/testing/:param', () => {})
+findMyWay.on('PUT', '/update', () => {})
 
 console.log(findMyWay.prettyPrint())
 // └── /
-//   ├── test (GET)
-//   │   └── /hello (GET)
-//   └── hello/world (GET)
+//     ├── test (GET)
+//     │   ├── /hello (GET)
+//     │   └── ing (GET)
+//     │       └── /:param (GET)
+//     └── update (PUT)
+```
+
+`prettyPrint` accepts an optional setting to use the internal routes array to render the tree.
+
+```js
+console.log(findMyWay.prettyPrint({ routesArray: true }))
+// └── / (-)
+//     ├── test (GET)
+//     │   └── /hello (GET)
+//     ├── testing (GET)
+//     │   └── /:param (GET)
+//     └── update (PUT)
 ```
 
 <a name="routes"></a>

--- a/index.js
+++ b/index.js
@@ -572,7 +572,7 @@ Router.prototype._onBadUrl = function (path) {
 }
 
 Router.prototype.prettyPrint = function (opts = {}) {
-  if (opts.routesArray) return prettyPrintRoutesArray(this.routes)
+  if (opts.commonPrefix) return prettyPrintRoutesArray(this.routes)
   const root = {
     prefix: '/',
     nodes: [],

--- a/index.js
+++ b/index.js
@@ -572,7 +572,8 @@ Router.prototype._onBadUrl = function (path) {
 }
 
 Router.prototype.prettyPrint = function (opts = {}) {
-  if (opts.commonPrefix) return prettyPrintRoutesArray(this.routes)
+  opts.commonPrefix = opts.commonPrefix === undefined ? true : opts.commonPrefix // default to original behaviour
+  if (!opts.commonPrefix) return prettyPrintRoutesArray(this.routes)
   const root = {
     prefix: '/',
     nodes: [],

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const assert = require('assert')
 const http = require('http')
 const fastDecode = require('fast-decode-uri-component')
 const isRegexSafe = require('safe-regex2')
-const { flattenNode, compressFlattenedNode, prettyPrintFlattenedNode } = require('./lib/pretty-print')
+const { flattenNode, compressFlattenedNode, prettyPrintFlattenedNode, prettyPrintRoutesArray } = require('./lib/pretty-print')
 const Node = require('./node')
 const Constrainer = require('./lib/constrainer')
 
@@ -571,7 +571,8 @@ Router.prototype._onBadUrl = function (path) {
   }
 }
 
-Router.prototype.prettyPrint = function () {
+Router.prototype.prettyPrint = function (opts = {}) {
+  if (opts.routesArray) return prettyPrintRoutesArray(this.routes)
   const root = {
     prefix: '/',
     nodes: [],

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -63,7 +63,7 @@ function prettyPrintRoutesArray (routeArray) {
 
   // draw tree
   tree = drawBranch(routeTree, null, true, false, true)
-  return tree
+  return `${tree}\n`
 }
 
 function buildRouteTree (mergedRouteArray, rootPath) {

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -5,6 +5,7 @@ const indent              = '    '
 const branchIndent        = '│   '
 const midBranchIndent     = '├── '
 const endBranchIndent     = '└── '
+const wildcardDelimiter   = '*'
 const pathDelimiter       = '/'
 const pathRegExp          = /(?=\/)/
 /* eslint-enable */
@@ -48,22 +49,33 @@ function prettyPrintRoutesArray (routeArray) {
 
   // insert root level path if none defined
   if (!mergedRouteArray.filter(r => r.path === pathDelimiter).length) {
-    mergedRouteArray.unshift({
+    const rootPath = {
       path: pathDelimiter,
       truncatedPath: '',
       methods: [],
-      opts: {},
+      opts: [],
       handlers: [],
       parents: [pathDelimiter]
-    })
+    }
+
+    // if wildcard route exists, insert root level after wildcard
+    if (mergedRouteArray.filter(r => r.path === wildcardDelimiter).length) {
+      mergedRouteArray.splice(1, 0, rootPath)
+    } else {
+      mergedRouteArray.unshift(rootPath)
+    }
   }
 
   // build tree
   const routeTree = buildRouteTree(mergedRouteArray)
 
   // draw tree
-  tree = drawBranch(routeTree, null, true, false, true)
-  return `${tree}\n`
+  routeTree.forEach((rootBranch, idx) => {
+    tree += drawBranch(rootBranch, null, idx === routeTree.length - 1, false, true)
+    tree += '\n' // newline characters inserted at beginning of drawing function to allow for nested paths
+  })
+
+  return tree
 }
 
 function buildRouteTree (mergedRouteArray, rootPath) {
@@ -75,7 +87,10 @@ function buildRouteTree (mergedRouteArray, rootPath) {
     let splitPath = route.path.split(pathRegExp)
 
     // add preceding slash for proper nesting
-    if (splitPath[0] !== pathDelimiter) splitPath = [pathDelimiter, splitPath[0].slice(1), ...splitPath.slice(1)]
+    if (splitPath[0] !== pathDelimiter) {
+      // handle wildcard route
+      if (splitPath[0] !== wildcardDelimiter) splitPath = [pathDelimiter, splitPath[0].slice(1), ...splitPath.slice(1)]
+    }
 
     // build tree
     splitPath.reduce((acc, path, pidx) => {
@@ -91,7 +106,7 @@ function buildRouteTree (mergedRouteArray, rootPath) {
   })
 
   // unfold root object from array
-  return result.find(res => res.path === rootPath)
+  return result
 }
 
 function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
@@ -101,7 +116,7 @@ function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
   if (!noPrefix) branch += `${prefix || ''}${endBranch ? endBranchIndent : midBranchIndent}`
   branch += `${pathSeg.path}`
 
-  if (pathSeg.handlers) branch += ` (${pathSeg.handlers.map(h => h.method + `${h.opts ? ' ' + JSON.stringify(h.opts) : ''}`).join(', ') || '-'})`
+  if (pathSeg.handlers) branch += ` (${pathSeg.handlers.map(h => h.method + `${h.opts && JSON.stringify(h.opts) !== '{}' ? ' ' + JSON.stringify(h.opts) : ''}`).join(', ') || '-'})`
   if (!noPrefix) prefix = `${prefix || ''}${endBranch ? indent : branchIndent}`
 
   pathSeg.children.forEach((child, idx) => {

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -1,3 +1,116 @@
+/* eslint-disable no-multi-spaces */
+const indent              = '    '
+const branchIndent        = '│   '
+const midBranchIndent     = '├── '
+const endBranchIndent     = '└── '
+const pathDelimiter       = '/'
+const pathRegExp          = /(?=\/)/
+/* eslint-enable */
+
+function prettyPrintRoutesArray (routeArray) {
+  const mergedRouteArray = []
+
+  let tree = ''
+
+  routeArray.sort((a, b) => {
+    if (!a.path || !b.path) return 0
+    return a.path.localeCompare(b.path)
+  })
+
+  // merge alike paths
+  for (let i = 0; i < routeArray.length; i++) {
+    const route = routeArray[i]
+    const pathExists = mergedRouteArray.find(r => route.path === r.path)
+    if (pathExists) {
+      // path already declared, add new method and break out of loop
+      pathExists.handlers.push({
+        method: route.method,
+        opts: route.opts.constraints || undefined
+      })
+      continue
+    }
+
+    const routeHandler = {
+      method: route.method,
+      opts: route.opts.constraints || undefined
+    }
+    mergedRouteArray.push({
+      path: route.path,
+      methods: [route.method],
+      opts: [route.opts],
+      handlers: [routeHandler],
+      parents: [],
+      branchLevel: 1
+    })
+  }
+
+  // insert root level path if none defined
+  if (!mergedRouteArray.filter(r => r.path === pathDelimiter).length) {
+    mergedRouteArray.unshift({
+      path: pathDelimiter,
+      truncatedPath: '',
+      methods: [],
+      opts: {},
+      handlers: [],
+      parents: [pathDelimiter]
+    })
+  }
+
+  // build tree
+  const routeTree = buildRouteTree(mergedRouteArray)
+
+  // draw tree
+  tree = drawBranch(routeTree, null, true, false, true)
+  return tree
+}
+
+function buildRouteTree (mergedRouteArray, rootPath) {
+  rootPath = rootPath || pathDelimiter
+
+  const result = []
+  const temp = { result }
+  mergedRouteArray.forEach((route, idx) => {
+    let splitPath = route.path.split(pathRegExp)
+
+    // add preceding slash for proper nesting
+    if (splitPath[0] !== pathDelimiter) splitPath = [pathDelimiter, splitPath[0].slice(1), ...splitPath.slice(1)]
+
+    // build tree
+    splitPath.reduce((acc, path, pidx) => {
+      if (!acc[path]) {
+        acc[path] = { result: [] }
+        const pathSeg = { path, children: acc[path].result }
+
+        if (pidx === splitPath.length - 1) pathSeg.handlers = route.handlers
+        acc.result.push(pathSeg)
+      }
+      return acc[path]
+    }, temp)
+  })
+
+  // unfold root object from array
+  return result.find(res => res.path === rootPath)
+}
+
+function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
+  let branch = ''
+
+  if (!noPrefix && !rootBranch) branch += '\n'
+  if (!noPrefix) branch += `${prefix || ''}${endBranch ? endBranchIndent : midBranchIndent}`
+  branch += `${pathSeg.path}`
+
+  if (pathSeg.handlers) branch += ` (${pathSeg.handlers.map(h => h.method + `${h.opts ? ' ' + JSON.stringify(h.opts) : ''}`).join(', ') || '-'})`
+  if (!noPrefix) prefix = `${prefix || ''}${endBranch ? indent : branchIndent}`
+
+  pathSeg.children.forEach((child, idx) => {
+    const endBranch = idx === pathSeg.children.length - 1
+    const skipPrefix = (!pathSeg.handlers && pathSeg.children.length === 1)
+    branch += drawBranch(child, prefix, endBranch, skipPrefix)
+  })
+
+  return branch
+}
+
 function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
   var paramName = ''
   const printHandlers = []
@@ -33,12 +146,12 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
       paramName += '\n'
     }
 
-    paramName += prefix + '    ' + name + ` ${suffix}`
+    paramName += prefix + indent + name + ` ${suffix}`
   })
 
-  var tree = `${prefix}${tail ? '└── ' : '├── '}${flattenedNode.prefix}${paramName}\n`
+  var tree = `${prefix}${tail ? endBranchIndent : midBranchIndent}${flattenedNode.prefix}${paramName}\n`
 
-  prefix = `${prefix}${tail ? '    ' : '│   '}`
+  prefix = `${prefix}${tail ? indent : branchIndent}`
   const labels = Object.keys(flattenedNode.children)
   for (var i = 0; i < labels.length; i++) {
     const child = flattenedNode.children[labels[i]]
@@ -54,7 +167,8 @@ function flattenNode (flattened, node) {
 
   if (node.children) {
     for (const child of Object.values(node.children)) {
-      const childPrefixSegments = child.prefix.split(/(?=\/)/) // split on the slash separator but use a regex to lookahead and not actually match it, preserving it in the returned string segments
+      // split on the slash separator but use a regex to lookahead and not actually match it, preserving it in the returned string segments
+      const childPrefixSegments = child.prefix.split(pathRegExp)
       let cursor = flattened
       let parent
       for (const segment of childPrefixSegments) {
@@ -69,7 +183,6 @@ function flattenNode (flattened, node) {
           parent.children[segment] = cursor
         }
       }
-
       flattenNode(cursor, child)
     }
   }
@@ -95,4 +208,4 @@ function compressFlattenedNode (flattenedNode) {
   return flattenedNode
 }
 
-module.exports = { flattenNode, compressFlattenedNode, prettyPrintFlattenedNode }
+module.exports = { flattenNode, compressFlattenedNode, prettyPrintFlattenedNode, prettyPrintRoutesArray }

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -112,7 +112,7 @@ function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
 }
 
 function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
-  var paramName = ''
+  let paramName = ''
   const printHandlers = []
 
   for (const node of flattenedNode.nodes) {
@@ -121,39 +121,50 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
     }
   }
 
-  printHandlers.forEach((handler, index) => {
-    let suffix = `(${handler.method}`
-    if (Object.keys(handler.constraints).length > 0) {
-      suffix += ' ' + JSON.stringify(handler.constraints)
-    }
-    suffix += ')'
-
-    let name = ''
-    if (flattenedNode.prefix.includes(':')) {
-      var params = handler.params
-      name = params[params.length - 1]
-      if (index > 0) {
-        name = ':' + name
+  if (printHandlers.length) {
+    printHandlers.forEach((handler, index) => {
+      let suffix = `(${handler.method || '-'}`
+      if (Object.keys(handler.constraints).length > 0) {
+        suffix += ' ' + JSON.stringify(handler.constraints)
       }
-    } else if (index > 0) {
-      name = flattenedNode.prefix
-    }
+      suffix += ')'
 
-    if (index === 0) {
-      paramName += name + ` ${suffix}`
-      return
-    } else {
-      paramName += '\n'
-    }
+      let name = ''
+      // find locations of parameters in prefix
+      const paramIndices = flattenedNode.prefix.split('').map((ch, idx) => ch === ':' ? idx : null).filter(idx => idx !== null)
+      if (paramIndices.length) {
+        let prevLoc = 0
+        paramIndices.forEach((loc, idx) => {
+          // find parameter in prefix
+          name += flattenedNode.prefix.slice(prevLoc, loc + 1)
+          // insert parameters
+          name += handler.params[handler.params.length - paramIndices.length + idx]
+          if (idx === paramIndices.length - 1) name += flattenedNode.prefix.slice(loc + 1)
+          prevLoc = loc + 1
+        })
+      } else {
+        // there are no parameters, return full object
+        name = flattenedNode.prefix
+      }
 
-    paramName += prefix + indent + name + ` ${suffix}`
-  })
+      if (index === 0) {
+        paramName += `${name} ${suffix}`
+        return
+      } else {
+        paramName += '\n'
+      }
 
-  var tree = `${prefix}${tail ? endBranchIndent : midBranchIndent}${flattenedNode.prefix}${paramName}\n`
+      paramName += prefix + indent + `${name} ${suffix}`
+    })
+  } else {
+    paramName = flattenedNode.prefix
+  }
+
+  let tree = `${prefix}${tail ? endBranchIndent : midBranchIndent}${paramName}\n`
 
   prefix = `${prefix}${tail ? indent : branchIndent}`
   const labels = Object.keys(flattenedNode.children)
-  for (var i = 0; i < labels.length; i++) {
+  for (let i = 0; i < labels.length; i++) {
     const child = flattenedNode.children[labels[i]]
     tree += prettyPrintFlattenedNode(child, prefix, i === (labels.length - 1))
   }

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -54,7 +54,7 @@ function prettyPrintRoutesArray (routeArray) {
       truncatedPath: '',
       methods: [],
       opts: [],
-      handlers: [],
+      handlers: [{}],
       parents: [pathDelimiter]
     }
 
@@ -116,7 +116,25 @@ function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
   if (!noPrefix) branch += `${prefix || ''}${endBranch ? endBranchIndent : midBranchIndent}`
   branch += `${pathSeg.path}`
 
-  if (pathSeg.handlers) branch += ` (${pathSeg.handlers.map(h => h.method + `${h.opts && JSON.stringify(h.opts) !== '{}' ? ' ' + JSON.stringify(h.opts) : ''}`).join(', ') || '-'})`
+  if (pathSeg.handlers) {
+    const flatHandlers = pathSeg.handlers.reduce((acc, curr) => {
+      const match = acc.findIndex(h => JSON.stringify(h.opts) === JSON.stringify(curr.opts))
+      if (match !== -1) {
+        acc[match].method = [acc[match].method, curr.method].join(', ')
+      } else {
+        acc.push(curr)
+      }
+      return acc
+    }, [])
+
+    flatHandlers.forEach((handler, idx) => {
+      if (idx > 0) branch += `${noPrefix ? '' : prefix}${endBranch ? indent : branchIndent}${pathSeg.path}`
+      branch += ` (${handler.method || '-'})`
+      if (handler.opts && JSON.stringify(handler.opts) !== '{}') branch += ` ${JSON.stringify(handler.opts)}`
+      if (flatHandlers.length > 1 && idx !== flatHandlers.length - 1) branch += '\n'
+    })
+  }
+
   if (!noPrefix) prefix = `${prefix || ''}${endBranch ? indent : branchIndent}`
 
   pathSeg.children.forEach((child, idx) => {
@@ -140,11 +158,10 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
 
   if (printHandlers.length) {
     printHandlers.forEach((handler, index) => {
-      let suffix = `(${handler.method || '-'}`
+      let suffix = `(${handler.method || '-'})`
       if (Object.keys(handler.constraints).length > 0) {
         suffix += ' ' + JSON.stringify(handler.constraints)
       }
-      suffix += ')'
 
       let name = ''
       // find locations of parameters in prefix
@@ -171,7 +188,7 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
         paramName += '\n'
       }
 
-      paramName += prefix + indent + `${name} ${suffix}`
+      paramName += `${prefix}${tail ? indent : branchIndent}${name} ${suffix}`
     })
   } else {
     paramName = flattenedNode.prefix

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -1,3 +1,5 @@
+'use strict'
+
 /* eslint-disable no-multi-spaces */
 const indent              = '    '
 const branchIndent        = '│   '

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -154,3 +154,39 @@ test('pretty print - multiple parameters are drawn appropriately', t => {
   t.is(typeof tree, 'string')
   t.equal(tree, expected)
 })
+
+test('pretty print - use routes array to draw flattened routes', t => {
+  t.plan(4)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/test', () => {})
+  findMyWay.on('GET', '/test/hello', () => {})
+  findMyWay.on('GET', '/testing', () => {})
+  findMyWay.on('GET', '/testing/:param', () => {})
+  findMyWay.on('PUT', '/update', () => {})
+
+  const radixTree = findMyWay.prettyPrint()
+  const arrayTree = findMyWay.prettyPrint({ commonPrefix: true })
+
+  const radixExpected = `└── /
+    ├── test (GET)
+    │   ├── /hello (GET)
+    │   └── ing (GET)
+    │       └── /:param (GET)
+    └── update (PUT)
+`
+  const arrayExpected = `└── / (-)
+    ├── test (GET)
+    │   └── /hello (GET)
+    ├── testing (GET)
+    │   └── /:param (GET)
+    └── update (PUT)
+`
+
+  t.is(typeof radixTree, 'string')
+  t.is(typeof arrayTree, 'string')
+
+  t.equal(radixTree, radixExpected)
+  t.equal(arrayTree, arrayExpected)
+})

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -124,8 +124,31 @@ test('pretty print - constrained parametric routes', t => {
   const expected = `└── /test (GET)
     /test (GET {"host":"auth.fastify.io"})
     └── /:hello (GET)
-        :hello (GET {"version":"1.1.2"})
-        :hello (GET {"version":"2.0.0"})
+        /:hello (GET {"version":"1.1.2"})
+        /:hello (GET {"version":"2.0.0"})
+`
+
+  t.is(typeof tree, 'string')
+  t.equal(tree, expected)
+})
+
+test('pretty print - multiple parameters are drawn appropriately', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+  findMyWay.on('GET', '/test', () => {})
+  // routes with a nested parameter (i.e. no handler for the /:param) were breaking the display
+  findMyWay.on('GET', '/test/:hello/there/:ladies', () => {})
+  findMyWay.on('GET', '/test/:hello/there/:ladies/and/:gents', () => {})
+  findMyWay.on('GET', '/test/are/:you/:ready/to/:rock', () => {})
+
+  const tree = findMyWay.prettyPrint()
+
+  const expected = `└── /test (GET)
+    └── /
+        ├── :hello/there/:ladies (GET)
+        │   └── /and/:gents (GET)
+        └── are/:you/:ready/to/:rock (GET)
 `
 
   t.is(typeof tree, 'string')

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -122,10 +122,10 @@ test('pretty print - constrained parametric routes', t => {
   const tree = findMyWay.prettyPrint()
 
   const expected = `└── /test (GET)
-    /test (GET {"host":"auth.fastify.io"})
+    /test (GET) {"host":"auth.fastify.io"}
     └── /:hello (GET)
-        /:hello (GET {"version":"1.1.2"})
-        /:hello (GET {"version":"2.0.0"})
+        /:hello (GET) {"version":"1.1.2"}
+        /:hello (GET) {"version":"2.0.0"}
 `
 
   t.is(typeof tree, 'string')
@@ -223,13 +223,17 @@ test('pretty print commonPrefix - handle constrained routes', t => {
   findMyWay.on('GET', '/test', () => {})
   findMyWay.on('GET', '/test', { constraints: { host: 'auth.fastify.io' } }, () => {})
   findMyWay.on('GET', '/test/:hello', () => {})
+  findMyWay.on('PUT', '/test/:hello', () => {})
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '1.1.2' } }, () => {})
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '2.0.0' } }, () => {})
 
   const arrayTree = findMyWay.prettyPrint({ commonPrefix: false })
   const arrayExpected = `└── / (-)
-    └── test (GET, GET {"host":"auth.fastify.io"})
-        └── /:hello (GET, GET {"version":"1.1.2"}, GET {"version":"2.0.0"})
+    └── test (GET)
+        test (GET) {"host":"auth.fastify.io"}
+        └── /:hello (GET, PUT)
+            /:hello (GET) {"version":"1.1.2"}
+            /:hello (GET) {"version":"2.0.0"}
 `
   t.is(typeof arrayTree, 'string')
   t.equal(arrayTree, arrayExpected)

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -166,8 +166,8 @@ test('pretty print commonPrefix - use routes array to draw flattened routes', t 
   findMyWay.on('GET', '/testing/:param', () => {})
   findMyWay.on('PUT', '/update', () => {})
 
-  const radixTree = findMyWay.prettyPrint()
-  const arrayTree = findMyWay.prettyPrint({ commonPrefix: true })
+  const radixTree = findMyWay.prettyPrint({ commonPrefix: true })
+  const arrayTree = findMyWay.prettyPrint({ commonPrefix: false })
 
   const radixExpected = `└── /
     ├── test (GET)
@@ -202,7 +202,7 @@ test('pretty print commonPrefix - handle wildcard root', t => {
   findMyWay.on('GET', '/testing/:param', () => {})
   findMyWay.on('PUT', '/update', () => {})
 
-  const arrayTree = findMyWay.prettyPrint({ commonPrefix: true })
+  const arrayTree = findMyWay.prettyPrint({ commonPrefix: false })
   const arrayExpected = `├── * (OPTIONS)
 └── / (-)
     ├── test/hello (GET)
@@ -226,7 +226,7 @@ test('pretty print commonPrefix - handle constrained routes', t => {
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '1.1.2' } }, () => {})
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '2.0.0' } }, () => {})
 
-  const arrayTree = findMyWay.prettyPrint({ commonPrefix: true })
+  const arrayTree = findMyWay.prettyPrint({ commonPrefix: false })
   const arrayExpected = `└── / (-)
     └── test (GET, GET {"host":"auth.fastify.io"})
         └── /:hello (GET, GET {"version":"1.1.2"}, GET {"version":"2.0.0"})

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -155,7 +155,7 @@ test('pretty print - multiple parameters are drawn appropriately', t => {
   t.equal(tree, expected)
 })
 
-test('pretty print - use routes array to draw flattened routes', t => {
+test('pretty print commonPrefix - use routes array to draw flattened routes', t => {
   t.plan(4)
 
   const findMyWay = FindMyWay()
@@ -191,7 +191,7 @@ test('pretty print - use routes array to draw flattened routes', t => {
   t.equal(arrayTree, arrayExpected)
 })
 
-test('pretty print - handle wildcard root', t => {
+test('pretty print commonPrefix - handle wildcard root', t => {
   t.plan(2)
 
   const findMyWay = FindMyWay()
@@ -211,6 +211,26 @@ test('pretty print - handle wildcard root', t => {
     └── update (PUT)
 `
 
+  t.is(typeof arrayTree, 'string')
+  t.equal(arrayTree, arrayExpected)
+})
+
+test('pretty print commonPrefix - handle constrained routes', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/test', () => {})
+  findMyWay.on('GET', '/test', { constraints: { host: 'auth.fastify.io' } }, () => {})
+  findMyWay.on('GET', '/test/:hello', () => {})
+  findMyWay.on('GET', '/test/:hello', { constraints: { version: '1.1.2' } }, () => {})
+  findMyWay.on('GET', '/test/:hello', { constraints: { version: '2.0.0' } }, () => {})
+
+  const arrayTree = findMyWay.prettyPrint({ commonPrefix: true })
+  const arrayExpected = `└── / (-)
+    └── test (GET, GET {"host":"auth.fastify.io"})
+        └── /:hello (GET, GET {"version":"1.1.2"}, GET {"version":"2.0.0"})
+`
   t.is(typeof arrayTree, 'string')
   t.equal(arrayTree, arrayExpected)
 })

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -190,3 +190,27 @@ test('pretty print - use routes array to draw flattened routes', t => {
   t.equal(radixTree, radixExpected)
   t.equal(arrayTree, arrayExpected)
 })
+
+test('pretty print - handle wildcard root', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('OPTIONS', '*', () => {})
+  findMyWay.on('GET', '/test/hello', () => {})
+  findMyWay.on('GET', '/testing', () => {})
+  findMyWay.on('GET', '/testing/:param', () => {})
+  findMyWay.on('PUT', '/update', () => {})
+
+  const arrayTree = findMyWay.prettyPrint({ commonPrefix: true })
+  const arrayExpected = `├── * (OPTIONS)
+└── / (-)
+    ├── test/hello (GET)
+    ├── testing (GET)
+    │   └── /:param (GET)
+    └── update (PUT)
+`
+
+  t.is(typeof arrayTree, 'string')
+  t.equal(arrayTree, arrayExpected)
+})


### PR DESCRIPTION
I found some unexpected behaviour in the way routes were displayed while I was testing this feature addition for `fastify-autoload` (https://github.com/fastify/fastify-autoload/pull/134)

The route parameters weren't being properly placed when drawing the tree if there was no root item. An example can be found in the PR linked above. I added a test for a specific instance where I was able to get it to break.

I have also added an additional tree-drawing function which uses the `findMyWay.routes` array instead of the radix tree, as it might be more intuitive to some users because it doesn't break trees by common prefixes (e.g. `home, homer, honour` in place of `ho->me, ho->me->r, ho->nour`)

If the added function is appropriate, I will add some tests for it.