### PR TITLE
Widen type defs to allow for nonstring version constraints

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare namespace Router {
     V1 = 'http1',
     V2 = 'http2'
   }
-
+  
   type HTTPMethod =
     | 'ACL'
     | 'BIND'
@@ -57,17 +57,17 @@ declare namespace Router {
     store: any
   ) => void;
 
-  interface ConstraintStrategy<V extends HTTPVersion> {
+  interface ConstraintStrategy<V extends HTTPVersion, ConstraintVersion = string> {
     name: string,
     mustMatchWhenDerived?: boolean,
     storage() : {
-      get(version: String) : Handler<V> | null,
-      set(version: String, store: Handler<V>) : void,
-      del(version: String) : void,
+      get(version: ConstraintVersion) : Handler<V> | null,
+      set(version: ConstraintVersion, store: Handler<V>) : void,
+      del(version: ConstraintVersion) : void,
       empty() : void
     },
-    validate(value: unknown): void,
-    deriveConstraint<Context>(req: Req<V>, ctx?: Context) : String,
+    validate?: (value: unknown) => asserts value is ConstraintVersion,
+    deriveConstraint<Context>(req: Req<V>, ctx?: Context) : ConstraintVersion,
   }
 
   interface Config<V extends HTTPVersion> {
@@ -91,7 +91,7 @@ declare namespace Router {
     ): void;
 
     constraints? : {
-      [key: string]: ConstraintStrategy<V>
+      [key: string]: ConstraintStrategy<V, unknown>
     }
   }
 

--- a/test/constraint.custom-nonstring.test.js
+++ b/test/constraint.custom-nonstring.test.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const assert = require('assert')
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('..')
+
+const customVersioning = {
+  name: 'version',
+  // storage factory
+  storage: function () {
+    let versions = []
+    return {
+      get: (version) => {
+        assert(typeof version === 'number')
+        return versions[version] || null
+      },
+      set: (version, store) => {
+        assert(typeof version === 'number')
+        versions[version] = store
+      },
+      del: (version) => {
+        assert(typeof version === 'number')
+        versions[version] = null
+      },
+      empty: () => {
+        versions = []
+      }
+    }
+  },
+  deriveConstraint: (req, ctx) => {
+    return Number(req.headers['accept-version'])
+  }
+}
+
+test('Custome deriveConstraint can return non-string versions', (t) => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay({ constraints: { version: customVersioning } })
+
+  findMyWay.on('GET', '/', { constraints: { version: 42 } }, (req, res, params) => {
+    t.strictEqual(req.headers['accept-version'], '42')
+  })
+
+  findMyWay.on('GET', '/', { constraints: { version: 43 } }, (req, res, params) => {
+    t.strictEqual(req.headers['accept-version'], '43')
+  })
+
+  findMyWay.lookup({
+    method: 'GET',
+    url: '/',
+    headers: { 'accept-version': '42' }
+  })
+  findMyWay.lookup({
+    method: 'GET',
+    url: '/',
+    headers: { 'accept-version': '43' }
+  })
+})

--- a/test/types/router.test-d.ts
+++ b/test/types/router.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 import * as Router from '../../'
 import { Http2ServerRequest, Http2ServerResponse } from 'http2'
 import { IncomingMessage, ServerResponse } from 'http'
@@ -110,4 +110,42 @@ let http2Res!: Http2ServerResponse;
   expectType<void>(router.reset())
   expectType<string>(router.prettyPrint())
 
+}
+
+// non-string versions 
+{
+  let handler: Router.Handler<Router.HTTPVersion.V2>
+
+  const versionConstraint: Router.ConstraintStrategy<Router.HTTPVersion.V2, number> = {
+    name: 'version',
+    deriveConstraint() { return 42 }, 
+    storage() {
+      return {
+        get (version: number) { return handler },
+        set (version: number) {},
+        del (version: number) {},
+        empty () {}
+      }
+    },
+  }
+
+  Router<Router.HTTPVersion.V2>({
+    constraints: {
+      version: versionConstraint
+    }
+  })
+
+  // NOTE: string is the default version type
+  expectError<Router.ConstraintStrategy<Router.HTTPVersion.V2>>({
+    name: 'version',
+    deriveConstraint(): number { return 42 }, 
+    storage() {
+      return {
+        get (version: string) { return handler },
+        set (version: string, handler) {},
+        del (version: string) {},
+        empty () {}
+      }
+    },
+  })
 }


### PR DESCRIPTION
find-my-way's design makes it agnostic as to the specific type and shape of a version, however the bundled types constrain versions to a string. This PR does three things:

1. Provides a test showing that non-string versions are supported.
1. Widens the typings to a generic, so that implemented strategies are consistently typed, with a string version as a default.
1. Marks `validate` as optional, because it is.