### PR TITLE
fix prettyPrint undefined method

### DIFF
--- a/node.js
+++ b/node.js
@@ -120,6 +120,7 @@ Node.prototype.split = function (length) {
       prefix: this.prefix.slice(length),
       children: this.children,
       kind: this.kind,
+      method: this.method,
       handlers: this.handlers.slice(0),
       regex: this.regex,
       constrainer: this.constrainer,

--- a/test/issue-182.test.js
+++ b/test/issue-182.test.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('..')
+
+test('Set method property when splitting node', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  function handler (req, res, params) {
+    t.pass()
+  }
+
+  findMyWay.on('GET', '/health-a/health', handler)
+  findMyWay.on('GET', '/health-b/health', handler)
+
+  t.notMatch(findMyWay.prettyPrint(), /undefined/)
+})


### PR DESCRIPTION
Related to [fastify/2938](https://github.com/fastify/fastify/issues/2938)

Caused by not setting method property when splitting node