### PR TITLE
Feature: adding support to display fastify hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can assign a `buildPrettyPrint` function to sanitize a route's `store` objec
 ```js
 
 const privateKey = new Symbol('private key')
-const store = { token: '12345' }
+const store = { token: '12345', [privateKey]: 'private value' }
 
 const router = require('find-my-way')({
   buildPrettyMeta: route => {
@@ -112,7 +112,7 @@ const router = require('find-my-way')({
       if (typeof k === 'symbol') delete cleanMeta[k]
     })
 
-    return cleanMeta
+    return cleanMeta // this will show up in the pretty print output!
   }
 })
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ const router = require('find-my-way')({
 })
 ```
 
-You can assign a `buildPrettyPrint` function to sanitize a route's `store` object to use with the `prettyPrint` functions. This function should accept a single object and return an object.
+You can assign a `buildPrettyMeta` function to sanitize a route's `store` object to use with the `prettyPrint` functions. This function should accept a single object and return an object.
 
 ```js
 

--- a/README.md
+++ b/README.md
@@ -409,8 +409,9 @@ router.find('GET', '/example', { host: 'fastify.io', version: '1.x' })
 ```
 
 <a name="pretty-print"></a>
-#### prettyPrint([{ commonPrefix: false }])
+#### prettyPrint([{ commonPrefix: false, includeMeta: true || [] }])
 Prints the representation of the internal radix tree, useful for debugging.
+
 ```js
 findMyWay.on('GET', '/test', () => {})
 findMyWay.on('GET', '/test/hello', () => {})
@@ -427,13 +428,47 @@ console.log(findMyWay.prettyPrint())
 //     └── update (PUT)
 ```
 
-`prettyPrint` accepts an optional setting to use the internal routes array to render the tree.
+`prettyPrint` accepts an optional setting to use the internal routes array
+to render the tree.
 
 ```js
 console.log(findMyWay.prettyPrint({ commonPrefix: false }))
 // └── / (-)
 //     ├── test (GET)
 //     │   └── /hello (GET)
+//     ├── testing (GET)
+//     │   └── /:param (GET)
+//     └── update (PUT)
+```
+
+To include a display of the `store` data passed to individual routes, the 
+option `includeMeta` may be passed. If set to `true` all items will be
+displayed, this can also be set to an array specifying which keys (if
+present) to be displayed.
+
+```js
+findMyWay.on('GET', '/test', () => {}, { onRequest: () => {}, authIDs => [1,2,3] })
+findMyWay.on('GET', '/test/hello', () => {}, { token: 'df123-4567' })
+findMyWay.on('GET', '/testing', () => {})
+findMyWay.on('GET', '/testing/:param', () => {})
+findMyWay.on('PUT', '/update', () => {})
+
+console.log(findMyWay.prettyPrint({ commonPrefix: false, includeMeta: ['onRequest'] }))
+// └── /
+//     ├── test (GET)
+//     │   • (onRequest) "anonymous()"
+//     │   ├── /hello (GET)
+//     │   └── ing (GET)
+//     │       └── /:param (GET)
+//     └── update (PUT)
+
+console.log(findMyWay.prettyPrint({ commonPrefix: true, includeMeta: true }))
+// └── / (-)
+//     ├── test (GET)
+//     │   • (onRequest) "anonymous()"
+//     │   • (authIDs) [1,2,3]
+//     │   └── /hello (GET)
+//     │       • (token) "df123-4567"
 //     ├── testing (GET)
 //     │   └── /:param (GET)
 //     └── update (PUT)

--- a/index.js
+++ b/index.js
@@ -580,7 +580,7 @@ Router.prototype._onBadUrl = function (path) {
 
 Router.prototype.prettyPrint = function (opts = {}) {
   opts.commonPrefix = opts.commonPrefix === undefined ? true : opts.commonPrefix // default to original behaviour
-  if (!opts.commonPrefix) return prettyPrintRoutesArray(this.routes, opts, this)
+  if (!opts.commonPrefix) return prettyPrintRoutesArray.call(this, this.routes, opts)
   const root = {
     prefix: '/',
     nodes: [],
@@ -595,7 +595,7 @@ Router.prototype.prettyPrint = function (opts = {}) {
 
   compressFlattenedNode(root)
 
-  return prettyPrintFlattenedNode(root, '', true, opts, this)
+  return prettyPrintFlattenedNode.call(this, root, '', true, opts)
 }
 
 for (var i in http.METHODS) {

--- a/index.js
+++ b/index.js
@@ -573,7 +573,7 @@ Router.prototype._onBadUrl = function (path) {
 
 Router.prototype.prettyPrint = function (opts = {}) {
   opts.commonPrefix = opts.commonPrefix === undefined ? true : opts.commonPrefix // default to original behaviour
-  if (!opts.commonPrefix) return prettyPrintRoutesArray(this.routes)
+  if (!opts.commonPrefix) return prettyPrintRoutesArray(this.routes, opts)
   const root = {
     prefix: '/',
     nodes: [],

--- a/index.js
+++ b/index.js
@@ -47,6 +47,13 @@ function Router (opts) {
     this.onBadUrl = null
   }
 
+  if (opts.buildPrettyMeta) {
+    assert(typeof opts.buildPrettyMeta === 'function', 'buildPrettyMeta must be a function')
+    this.buildPrettyMeta = opts.buildPrettyMeta
+  } else {
+    this.buildPrettyMeta = defaultBuildPrettyMeta
+  }
+
   this.caseSensitive = opts.caseSensitive === undefined ? true : opts.caseSensitive
   this.ignoreTrailingSlash = opts.ignoreTrailingSlash || false
   this.maxParamLength = opts.maxParamLength || 100
@@ -573,7 +580,7 @@ Router.prototype._onBadUrl = function (path) {
 
 Router.prototype.prettyPrint = function (opts = {}) {
   opts.commonPrefix = opts.commonPrefix === undefined ? true : opts.commonPrefix // default to original behaviour
-  if (!opts.commonPrefix) return prettyPrintRoutesArray(this.routes, opts)
+  if (!opts.commonPrefix) return prettyPrintRoutesArray(this.routes, opts, this)
   const root = {
     prefix: '/',
     nodes: [],
@@ -588,7 +595,7 @@ Router.prototype.prettyPrint = function (opts = {}) {
 
   compressFlattenedNode(root)
 
-  return prettyPrintFlattenedNode(root, '', true, opts)
+  return prettyPrintFlattenedNode(root, '', true, opts, this)
 }
 
 for (var i in http.METHODS) {
@@ -649,4 +656,11 @@ function getClosingParenthensePosition (path, idx) {
   }
 
   throw new TypeError('Invalid regexp expression in "' + path + '"')
+}
+
+function defaultBuildPrettyMeta (route) {
+  // buildPrettyMeta function must return an object, which will be parsed into key/value pairs for display
+  if (!route) return {}
+  if (!route.store) return {}
+  return Object.assign({}, route.store)
 }

--- a/index.js
+++ b/index.js
@@ -588,7 +588,7 @@ Router.prototype.prettyPrint = function (opts = {}) {
 
   compressFlattenedNode(root)
 
-  return prettyPrintFlattenedNode(root, '', true)
+  return prettyPrintFlattenedNode(root, '', true, opts)
 }
 
 for (var i in http.METHODS) {

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -10,7 +10,24 @@ const pathDelimiter       = '/'
 const pathRegExp          = /(?=\/)/
 /* eslint-enable */
 
-function prettyPrintRoutesArray (routeArray) {
+function parseFunctionName (fn) {
+  let fName = fn.name
+  if (!fName) return ''
+
+  fName = fName.replace('bound ', '')
+  return fName || 'anonymous'
+}
+
+function buildHooksObject (route, hookList) {
+  const out = {}
+  hookList.forEach(h => {
+    if (route.store[h] && route.store[h].length) out[h] = route.store[h].map(fn => parseFunctionName(fn))
+  })
+  return out
+}
+
+function prettyPrintRoutesArray (routeArray, opts = {}) {
+  opts.hooksArray = opts.hooksArray || [] // array of hooks to display
   const mergedRouteArray = []
 
   let tree = ''
@@ -28,22 +45,22 @@ function prettyPrintRoutesArray (routeArray) {
       // path already declared, add new method and break out of loop
       pathExists.handlers.push({
         method: route.method,
-        opts: route.opts.constraints || undefined
+        opts: route.opts.constraints || undefined,
+        hooks: opts.includeHooks ? buildHooksObject(route, opts.hooksArray) : null
       })
       continue
     }
 
     const routeHandler = {
       method: route.method,
-      opts: route.opts.constraints || undefined
+      opts: route.opts.constraints || undefined,
+      hooks: opts.includeHooks ? buildHooksObject(route, opts.hooksArray) : null
     }
     mergedRouteArray.push({
       path: route.path,
       methods: [route.method],
       opts: [route.opts],
-      handlers: [routeHandler],
-      parents: [],
-      branchLevel: 1
+      handlers: [routeHandler]
     })
   }
 
@@ -54,8 +71,7 @@ function prettyPrintRoutesArray (routeArray) {
       truncatedPath: '',
       methods: [],
       opts: [],
-      handlers: [{}],
-      parents: [pathDelimiter]
+      handlers: [{}]
     }
 
     // if wildcard route exists, insert root level after wildcard
@@ -128,11 +144,19 @@ function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
     }, [])
 
     flatHandlers.forEach((handler, idx) => {
-      if (idx > 0) branch += `${noPrefix ? '' : prefix}${endBranch ? indent : branchIndent}${pathSeg.path}`
+      if (idx > 0) branch += `${noPrefix ? '' : prefix || ''}${endBranch ? indent : branchIndent}${pathSeg.path}`
       branch += ` (${handler.method || '-'})`
       if (handler.opts && JSON.stringify(handler.opts) !== '{}') branch += ` ${JSON.stringify(handler.opts)}`
+      if (handler.hooks) {
+        Object.keys(handler.hooks).forEach((h, hidx) => {
+          branch += `\n${noPrefix ? '' : prefix || ''}${endBranch ? indent : branchIndent}`
+          branch += `• (${h}) ${JSON.stringify(handler.hooks[h])}`
+        })
+      }
       if (flatHandlers.length > 1 && idx !== flatHandlers.length - 1) branch += '\n'
     })
+  } else {
+    if (pathSeg.children.length > 1) branch += ' (-)'
   }
 
   if (!noPrefix) prefix = `${prefix || ''}${endBranch ? indent : branchIndent}`

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -25,9 +25,9 @@ function parseMeta (meta) {
   return meta
 }
 
-function buildMetaObject (route, metaArray, _fmw) {
+function buildMetaObject (route, metaArray) {
   const out = {}
-  const cleanMeta = _fmw.buildPrettyMeta(route)
+  const cleanMeta = this.buildPrettyMeta(route)
   if (!Array.isArray(metaArray)) metaArray = cleanMeta ? Reflect.ownKeys(cleanMeta) : []
   metaArray.forEach(m => {
     const metaKey = typeof m === 'symbol' ? m.toString() : m
@@ -38,8 +38,8 @@ function buildMetaObject (route, metaArray, _fmw) {
   return out
 }
 
-function prettyPrintRoutesArray (routeArray, opts = {}, _fmw) {
-  if (!_fmw) throw new Error('router not available')
+function prettyPrintRoutesArray (routeArray, opts = {}) {
+  if (!this.buildPrettyMeta) throw new Error('buildPrettyMeta not defined')
   opts.includeMeta = opts.includeMeta || null // array of meta objects to display
   const mergedRouteArray = []
 
@@ -59,7 +59,7 @@ function prettyPrintRoutesArray (routeArray, opts = {}, _fmw) {
       pathExists.handlers.push({
         method: route.method,
         opts: route.opts.constraints || undefined,
-        meta: opts.includeMeta ? buildMetaObject(route, opts.includeMeta, _fmw) : null
+        meta: opts.includeMeta ? buildMetaObject.call(this, route, opts.includeMeta) : null
       })
       continue
     }
@@ -67,7 +67,7 @@ function prettyPrintRoutesArray (routeArray, opts = {}, _fmw) {
     const routeHandler = {
       method: route.method,
       opts: route.opts.constraints || undefined,
-      meta: opts.includeMeta ? buildMetaObject(route, opts.includeMeta, _fmw) : null
+      meta: opts.includeMeta ? buildMetaObject.call(this, route, opts.includeMeta) : null
     }
     mergedRouteArray.push({
       path: route.path,
@@ -183,8 +183,8 @@ function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
   return branch
 }
 
-function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts, _fmw) {
-  if (!_fmw) throw new Error('router not available')
+function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts) {
+  if (!this.buildPrettyMeta) throw new Error('buildPrettyMeta not defined')
   opts.includeMeta = opts.includeMeta || null // array of meta items to display
   let paramName = ''
   const printHandlers = []
@@ -226,7 +226,7 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts, _fmw) {
         paramName += `\n${prefix}${tail ? indent : branchIndent}${name} ${suffix}`
       }
       if (opts.includeMeta) {
-        const meta = buildMetaObject(handler, opts.includeMeta, _fmw)
+        const meta = buildMetaObject.call(this, handler, opts.includeMeta)
         Object.keys(meta).forEach((m, hidx) => {
           paramName += `\n${prefix || ''}${tail ? indent : branchIndent}`
           paramName += `• (${m}) ${JSON.stringify(meta[m])}`
@@ -243,7 +243,7 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts, _fmw) {
   const labels = Object.keys(flattenedNode.children)
   for (let i = 0; i < labels.length; i++) {
     const child = flattenedNode.children[labels[i]]
-    tree += prettyPrintFlattenedNode(child, prefix, i === (labels.length - 1), opts, _fmw)
+    tree += prettyPrintFlattenedNode.call(this, child, prefix, i === (labels.length - 1), opts)
   }
   return tree
 }

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -170,7 +170,8 @@ function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
   return branch
 }
 
-function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
+function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts) {
+  opts.hooksArray = opts.hooksArray || [] // array of hooks to display
   let paramName = ''
   const printHandlers = []
 
@@ -207,12 +208,17 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
 
       if (index === 0) {
         paramName += `${name} ${suffix}`
-        return
       } else {
-        paramName += '\n'
+        paramName += `\n${prefix}${tail ? indent : branchIndent}${name} ${suffix}`
       }
 
-      paramName += `${prefix}${tail ? indent : branchIndent}${name} ${suffix}`
+      if (opts.includeHooks) {
+        const hooks = buildHooksObject(handler, opts.hooksArray)
+        Object.keys(hooks).forEach((h, hidx) => {
+          paramName += `\n${prefix || ''}${tail ? indent : branchIndent}`
+          paramName += `• (${h}) ${JSON.stringify(hooks[h])}`
+        })
+      }
     })
   } else {
     paramName = flattenedNode.prefix
@@ -224,7 +230,7 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail) {
   const labels = Object.keys(flattenedNode.children)
   for (let i = 0; i < labels.length; i++) {
     const child = flattenedNode.children[labels[i]]
-    tree += prettyPrintFlattenedNode(child, prefix, i === (labels.length - 1))
+    tree += prettyPrintFlattenedNode(child, prefix, i === (labels.length - 1), opts)
   }
   return tree
 }

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -11,10 +11,10 @@ const pathRegExp          = /(?=\/)/
 /* eslint-enable */
 
 function parseFunctionName (fn) {
-  let fName = fn.name || 'anonymous'
+  let fName = fn.name || ''
 
-  fName = fName.replace('bound ', '')
-  fName += '()'
+  fName = fName.replace('bound', '').trim()
+  fName = (fName || 'anonymous') + '()'
   return fName
 }
 

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -12,22 +12,33 @@ const pathRegExp          = /(?=\/)/
 
 function parseFunctionName (fn) {
   let fName = fn.name
-  if (!fName) return ''
+  if (!fName) return 'anonymous'
 
   fName = fName.replace('bound ', '')
   return fName || 'anonymous'
 }
 
-function buildHooksObject (route, hookList) {
+function buildMetaObject (route, metaArray) {
   const out = {}
-  hookList.forEach(h => {
-    if (route.store[h] && route.store[h].length) out[h] = route.store[h].map(fn => parseFunctionName(fn))
+  if (!Array.isArray(metaArray)) metaArray = route.store ? Object.keys(route.store) : []
+  metaArray.forEach(m => {
+    if (route.store && route.store[m]) {
+      const curr = route.store[m]
+      if (Array.isArray(curr)) {
+        out[m] = curr.map(meta => {
+          if (typeof meta === 'function') return parseFunctionName(meta)
+          return meta
+        })
+      } else {
+        out[m] = curr
+      }
+    }
   })
   return out
 }
 
 function prettyPrintRoutesArray (routeArray, opts = {}) {
-  opts.hooksArray = opts.hooksArray || [] // array of hooks to display
+  opts.includeMeta = opts.includeMeta || null // array of meta objects to display
   const mergedRouteArray = []
 
   let tree = ''
@@ -46,7 +57,7 @@ function prettyPrintRoutesArray (routeArray, opts = {}) {
       pathExists.handlers.push({
         method: route.method,
         opts: route.opts.constraints || undefined,
-        hooks: opts.includeHooks ? buildHooksObject(route, opts.hooksArray) : null
+        meta: opts.includeMeta ? buildMetaObject(route, opts.includeMeta) : null
       })
       continue
     }
@@ -54,7 +65,7 @@ function prettyPrintRoutesArray (routeArray, opts = {}) {
     const routeHandler = {
       method: route.method,
       opts: route.opts.constraints || undefined,
-      hooks: opts.includeHooks ? buildHooksObject(route, opts.hooksArray) : null
+      meta: opts.includeMeta ? buildMetaObject(route, opts.includeMeta) : null
     }
     mergedRouteArray.push({
       path: route.path,
@@ -147,10 +158,10 @@ function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
       if (idx > 0) branch += `${noPrefix ? '' : prefix || ''}${endBranch ? indent : branchIndent}${pathSeg.path}`
       branch += ` (${handler.method || '-'})`
       if (handler.opts && JSON.stringify(handler.opts) !== '{}') branch += ` ${JSON.stringify(handler.opts)}`
-      if (handler.hooks) {
-        Object.keys(handler.hooks).forEach((h, hidx) => {
+      if (handler.meta) {
+        Object.keys(handler.meta).forEach((m, hidx) => {
           branch += `\n${noPrefix ? '' : prefix || ''}${endBranch ? indent : branchIndent}`
-          branch += `• (${h}) ${JSON.stringify(handler.hooks[h])}`
+          branch += `• (${m}) ${JSON.stringify(handler.meta[m])}`
         })
       }
       if (flatHandlers.length > 1 && idx !== flatHandlers.length - 1) branch += '\n'
@@ -171,7 +182,7 @@ function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
 }
 
 function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts) {
-  opts.hooksArray = opts.hooksArray || [] // array of hooks to display
+  opts.includeMeta = opts.includeMeta || null // array of meta items to display
   let paramName = ''
   const printHandlers = []
 
@@ -211,12 +222,11 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts) {
       } else {
         paramName += `\n${prefix}${tail ? indent : branchIndent}${name} ${suffix}`
       }
-
-      if (opts.includeHooks) {
-        const hooks = buildHooksObject(handler, opts.hooksArray)
-        Object.keys(hooks).forEach((h, hidx) => {
+      if (opts.includeMeta) {
+        const meta = buildMetaObject(handler, opts.includeMeta)
+        Object.keys(meta).forEach((m, hidx) => {
           paramName += `\n${prefix || ''}${tail ? indent : branchIndent}`
-          paramName += `• (${h}) ${JSON.stringify(hooks[h])}`
+          paramName += `• (${m}) ${JSON.stringify(meta[m])}`
         })
       }
     })

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -11,11 +11,11 @@ const pathRegExp          = /(?=\/)/
 /* eslint-enable */
 
 function parseFunctionName (fn) {
-  let fName = fn.name
-  if (!fName) return 'anonymous'
+  let fName = fn.name || 'anonymous'
 
   fName = fName.replace('bound ', '')
-  return fName || 'anonymous'
+  fName += '()'
+  return fName
 }
 
 function buildMetaObject (route, metaArray) {
@@ -29,6 +29,8 @@ function buildMetaObject (route, metaArray) {
           if (typeof meta === 'function') return parseFunctionName(meta)
           return meta
         })
+      } else if (typeof curr === 'function') {
+        out[m] = parseFunctionName(curr)
       } else {
         out[m] = curr
       }

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -18,22 +18,20 @@ function parseFunctionName (fn) {
   return fName
 }
 
+function parseMeta (meta) {
+  if (Array.isArray(meta)) return meta.map(m => parseMeta(m))
+  if (typeof meta === 'symbol') return meta.toString()
+  if (typeof meta === 'function') return parseFunctionName(meta)
+  return meta
+}
+
 function buildMetaObject (route, metaArray) {
   const out = {}
-  if (!Array.isArray(metaArray)) metaArray = route.store ? Object.keys(route.store) : []
+  if (!Array.isArray(metaArray)) metaArray = route.store ? Reflect.ownKeys(route.store) : []
   metaArray.forEach(m => {
+    const metaKey = typeof m === 'symbol' ? m.toString() : m
     if (route.store && route.store[m]) {
-      const curr = route.store[m]
-      if (Array.isArray(curr)) {
-        out[m] = curr.map(meta => {
-          if (typeof meta === 'function') return parseFunctionName(meta)
-          return meta
-        })
-      } else if (typeof curr === 'function') {
-        out[m] = parseFunctionName(curr)
-      } else {
-        out[m] = curr
-      }
+      out[metaKey] = parseMeta(route.store[m])
     }
   })
   return out
@@ -161,7 +159,7 @@ function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
       branch += ` (${handler.method || '-'})`
       if (handler.opts && JSON.stringify(handler.opts) !== '{}') branch += ` ${JSON.stringify(handler.opts)}`
       if (handler.meta) {
-        Object.keys(handler.meta).forEach((m, hidx) => {
+        Reflect.ownKeys(handler.meta).forEach((m, hidx) => {
           branch += `\n${noPrefix ? '' : prefix || ''}${endBranch ? indent : branchIndent}`
           branch += `• (${m}) ${JSON.stringify(handler.meta[m])}`
         })

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -25,19 +25,21 @@ function parseMeta (meta) {
   return meta
 }
 
-function buildMetaObject (route, metaArray) {
+function buildMetaObject (route, metaArray, _fmw) {
   const out = {}
-  if (!Array.isArray(metaArray)) metaArray = route.store ? Reflect.ownKeys(route.store) : []
+  const cleanMeta = _fmw.buildPrettyMeta(route)
+  if (!Array.isArray(metaArray)) metaArray = cleanMeta ? Reflect.ownKeys(cleanMeta) : []
   metaArray.forEach(m => {
     const metaKey = typeof m === 'symbol' ? m.toString() : m
-    if (route.store && route.store[m]) {
-      out[metaKey] = parseMeta(route.store[m])
+    if (cleanMeta && cleanMeta[m]) {
+      out[metaKey] = parseMeta(cleanMeta[m])
     }
   })
   return out
 }
 
-function prettyPrintRoutesArray (routeArray, opts = {}) {
+function prettyPrintRoutesArray (routeArray, opts = {}, _fmw) {
+  if (!_fmw) throw new Error('router not available')
   opts.includeMeta = opts.includeMeta || null // array of meta objects to display
   const mergedRouteArray = []
 
@@ -57,7 +59,7 @@ function prettyPrintRoutesArray (routeArray, opts = {}) {
       pathExists.handlers.push({
         method: route.method,
         opts: route.opts.constraints || undefined,
-        meta: opts.includeMeta ? buildMetaObject(route, opts.includeMeta) : null
+        meta: opts.includeMeta ? buildMetaObject(route, opts.includeMeta, _fmw) : null
       })
       continue
     }
@@ -65,7 +67,7 @@ function prettyPrintRoutesArray (routeArray, opts = {}) {
     const routeHandler = {
       method: route.method,
       opts: route.opts.constraints || undefined,
-      meta: opts.includeMeta ? buildMetaObject(route, opts.includeMeta) : null
+      meta: opts.includeMeta ? buildMetaObject(route, opts.includeMeta, _fmw) : null
     }
     mergedRouteArray.push({
       path: route.path,
@@ -181,7 +183,8 @@ function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
   return branch
 }
 
-function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts) {
+function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts, _fmw) {
+  if (!_fmw) throw new Error('router not available')
   opts.includeMeta = opts.includeMeta || null // array of meta items to display
   let paramName = ''
   const printHandlers = []
@@ -223,7 +226,7 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts) {
         paramName += `\n${prefix}${tail ? indent : branchIndent}${name} ${suffix}`
       }
       if (opts.includeMeta) {
-        const meta = buildMetaObject(handler, opts.includeMeta)
+        const meta = buildMetaObject(handler, opts.includeMeta, _fmw)
         Object.keys(meta).forEach((m, hidx) => {
           paramName += `\n${prefix || ''}${tail ? indent : branchIndent}`
           paramName += `• (${m}) ${JSON.stringify(meta[m])}`
@@ -240,7 +243,7 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts) {
   const labels = Object.keys(flattenedNode.children)
   for (let i = 0; i < labels.length; i++) {
     const child = flattenedNode.children[labels[i]]
-    tree += prettyPrintFlattenedNode(child, prefix, i === (labels.length - 1), opts)
+    tree += prettyPrintFlattenedNode(child, prefix, i === (labels.length - 1), opts, _fmw)
   }
   return tree
 }

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -238,3 +238,50 @@ test('pretty print commonPrefix - handle constrained routes', t => {
   t.is(typeof arrayTree, 'string')
   t.equal(arrayTree, arrayExpected)
 })
+
+test('pretty print includeMeta - commonPrefix: false', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+  const namedFunction = () => {}
+  const store = {
+    onRequest: [() => {}, namedFunction],
+    onTimeout: [() => {}],
+    genericMeta: 'meta',
+    mixedMeta: ['mixed items', { an: 'object' }],
+    objectMeta: { one: '1', two: 2 }
+  }
+
+  findMyWay.on('GET', '/test', () => {}, store)
+  findMyWay.on('GET', '/test', { constraints: { host: 'auth.fastify.io' } }, () => {}, store)
+  findMyWay.on('GET', '/test/:hello', () => {}, store)
+  findMyWay.on('PUT', '/test/:hello', () => {}, store)
+  findMyWay.on('GET', '/test/:hello', { constraints: { version: '1.1.2' } }, () => {})
+  findMyWay.on('GET', '/test/:hello', { constraints: { version: '2.0.0' } }, () => {})
+
+  const arrayTree = findMyWay.prettyPrint({ commonPrefix: false, includeMeta: true })
+  const arrayExpected = `└── / (-)
+    └── test (GET)
+        • (onRequest) ["anonymous","namedFunction"]
+        • (onTimeout) ["anonymous"]
+        • (genericMeta) "meta"
+        • (mixedMeta) ["mixed items",{"an":"object"}]
+        • (objectMeta) {"one":"1","two":2}
+        test (GET) {"host":"auth.fastify.io"}
+        • (onRequest) ["anonymous","namedFunction"]
+        • (onTimeout) ["anonymous"]
+        • (genericMeta) "meta"
+        • (mixedMeta) ["mixed items",{"an":"object"}]
+        • (objectMeta) {"one":"1","two":2}
+        └── /:hello (GET, PUT)
+            • (onRequest) ["anonymous","namedFunction"]
+            • (onTimeout) ["anonymous"]
+            • (genericMeta) "meta"
+            • (mixedMeta) ["mixed items",{"an":"object"}]
+            • (objectMeta) {"one":"1","two":2}
+            /:hello (GET) {"version":"1.1.2"}
+            /:hello (GET) {"version":"2.0.0"}
+`
+  t.is(typeof arrayTree, 'string')
+  t.equal(arrayTree, arrayExpected)
+})

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -253,6 +253,8 @@ test('pretty print includeMeta - commonPrefix: true', t => {
     functionMeta: namedFunction
   }
 
+  store[Symbol('symbolKey')] = Symbol('symbolValue')
+
   findMyWay.on('GET', '/test', () => {}, store)
   findMyWay.on('GET', '/test', { constraints: { host: 'auth.fastify.io' } }, () => {}, store)
   findMyWay.on('GET', '/testing/:hello', () => {}, store)
@@ -269,6 +271,7 @@ test('pretty print includeMeta - commonPrefix: true', t => {
     │   • (mixedMeta) ["mixed items",{"an":"object"}]
     │   • (objectMeta) {"one":"1","two":2}
     │   • (functionMeta) "namedFunction()"
+    │   • (Symbol(symbolKey)) "Symbol(symbolValue)"
     │   test (GET) {"host":"auth.fastify.io"}
     │   • (onRequest) ["anonymous()","namedFunction()"]
     │   • (onTimeout) ["anonymous()"]
@@ -276,6 +279,7 @@ test('pretty print includeMeta - commonPrefix: true', t => {
     │   • (mixedMeta) ["mixed items",{"an":"object"}]
     │   • (objectMeta) {"one":"1","two":2}
     │   • (functionMeta) "namedFunction()"
+    │   • (Symbol(symbolKey)) "Symbol(symbolValue)"
     │   ├── ing/:hello (GET)
     │   │   • (onRequest) ["anonymous()","namedFunction()"]
     │   │   • (onTimeout) ["anonymous()"]
@@ -283,6 +287,7 @@ test('pretty print includeMeta - commonPrefix: true', t => {
     │   │   • (mixedMeta) ["mixed items",{"an":"object"}]
     │   │   • (objectMeta) {"one":"1","two":2}
     │   │   • (functionMeta) "namedFunction()"
+    │   │   • (Symbol(symbolKey)) "Symbol(symbolValue)"
     │   └── /:hello (GET) {"version":"1.1.2"}
     │       /:hello (GET) {"version":"2.0.0"}
     └── tested/:hello (PUT)
@@ -292,6 +297,7 @@ test('pretty print includeMeta - commonPrefix: true', t => {
         • (mixedMeta) ["mixed items",{"an":"object"}]
         • (objectMeta) {"one":"1","two":2}
         • (functionMeta) "namedFunction()"
+        • (Symbol(symbolKey)) "Symbol(symbolValue)"
 `
   const radixTreeSpecific = findMyWay.prettyPrint({ commonPrefix: true, includeMeta: ['onTimeout', 'objectMeta', 'nonExistent'] })
   const radixTreeSpecificExpected = `└── /
@@ -345,6 +351,8 @@ test('pretty print includeMeta - commonPrefix: false', t => {
     functionMeta: namedFunction
   }
 
+  store[Symbol('symbolKey')] = Symbol('symbolValue')
+
   findMyWay.on('GET', '/test', () => {}, store)
   findMyWay.on('GET', '/test', { constraints: { host: 'auth.fastify.io' } }, () => {}, store)
   findMyWay.on('GET', '/test/:hello', () => {}, store)
@@ -361,6 +369,7 @@ test('pretty print includeMeta - commonPrefix: false', t => {
         • (mixedMeta) ["mixed items",{"an":"object"}]
         • (objectMeta) {"one":"1","two":2}
         • (functionMeta) "namedFunction()"
+        • (Symbol(symbolKey)) "Symbol(symbolValue)"
         test (GET) {"host":"auth.fastify.io"}
         • (onRequest) ["anonymous()","namedFunction()"]
         • (onTimeout) ["anonymous()"]
@@ -368,6 +377,7 @@ test('pretty print includeMeta - commonPrefix: false', t => {
         • (mixedMeta) ["mixed items",{"an":"object"}]
         • (objectMeta) {"one":"1","two":2}
         • (functionMeta) "namedFunction()"
+        • (Symbol(symbolKey)) "Symbol(symbolValue)"
         └── /:hello (GET, PUT)
             • (onRequest) ["anonymous()","namedFunction()"]
             • (onTimeout) ["anonymous()"]
@@ -375,6 +385,7 @@ test('pretty print includeMeta - commonPrefix: false', t => {
             • (mixedMeta) ["mixed items",{"an":"object"}]
             • (objectMeta) {"one":"1","two":2}
             • (functionMeta) "namedFunction()"
+            • (Symbol(symbolKey)) "Symbol(symbolValue)"
             /:hello (GET) {"version":"1.1.2"}
             /:hello (GET) {"version":"2.0.0"}
 `


### PR DESCRIPTION
Re: https://github.com/fastify/fastify/issues/2993

Adds ability to display hooks in `prettyPrint` output.

```
commonPrefix: false

   ├── /pages (GET)
   │   • (onTimeout) ["timeoutHook"]
   │   • (onRequest) ["anonymous","authenticate_token"]
   │   ├── / (GET)
   │   │   • (onTimeout) ["timeoutHook"]
   │   │   • (onRequest) ["anonymous","authenticate_token"]
   │   ├── /:id (GET)
   │   │   • (onTimeout) ["timeoutHook"]
   │   │   • (onRequest) ["anonymous","authenticate_token"]
   │   │   └── / (GET)
   │   │       • (onTimeout) ["timeoutHook"]
   │   │       • (onRequest) ["anonymous","authenticate_token"]
   │   ├── /new (POST)
   │   │   • (onTimeout) ["timeoutHook"]
   │   │   • (onRequest) ["anonymous","authenticate_token"]
   │   ├── /testing (GET) {"version":"1.0"}
   │   │   • (onTimeout) ["timeoutHook"]
   │   │   • (onRequest) ["anonymous","authenticate_token"]
   │   │   /testing (GET, PUT) {"version":"1.1"}
   │   │   • (onTimeout) ["timeoutHook"]
   │   │   • (onRequest) ["anonymous","authenticate_token"]
   │   └── /update (POST)
   │       • (onTimeout) ["timeoutHook"]
   │       • (onRequest) ["anonymous","authenticate_token"]
```

```
commonPrefix: true

   │   └── p
   │       ├── ages (GET)
   │       │   • (onTimeout) ["timeoutHook"]
   │       │   • (onRequest) ["anonymous","authenticate_token"]
   │       │   └── / (GET)
   │       │       • (onTimeout) ["timeoutHook"]
   │       │       • (onRequest) ["anonymous","authenticate_token"]
   │       │       ├── testing (GET) {"version":"1.0"}
   │       │       │   • (onTimeout) ["timeoutHook"]
   │       │       │   • (onRequest) ["anonymous","authenticate_token"]
   │       │       │   testing (GET) {"version":"1.1"}
   │       │       │   • (onTimeout) ["timeoutHook"]
   │       │       │   • (onRequest) ["anonymous","authenticate_token"]
   │       │       ├── :id (GET)
   │       │       │   • (onTimeout) ["timeoutHook"]
   │       │       │   • (onRequest) ["anonymous","authenticate_token"]
   │       │       │   └── / (GET)
   │       │       │       • (onTimeout) ["timeoutHook"]
   │       │       │       • (onRequest) ["anonymous","authenticate_token"]
   │       │       ├── new (POST)
   │       │       │   • (onTimeout) ["timeoutHook"]
   │       │       │   • (onRequest) ["anonymous","authenticate_token"]
   │       │       └── update (POST)
   │       │           • (onTimeout) ["timeoutHook"]
   │       │           • (onRequest) ["anonymous","authenticate_token"]
```
Enabled by `opts.includeHooks` and specified by `opts.hooksArray` (the latter defaults to `fastify/Hooks.supportedHooks`).