### PR TITLE
add content negotiation constraint

### DIFF
--- a/lib/constrainer.js
+++ b/lib/constrainer.js
@@ -2,13 +2,15 @@
 
 const acceptVersionStrategy = require('./strategies/accept-version')
 const acceptHostStrategy = require('./strategies/accept-host')
+const contentNegotiationForGet = require('./strategies/content-negotiation/content-negotiation.get')
 const assert = require('assert')
 
 class Constrainer {
   constructor (customStrategies) {
     this.strategies = {
       version: acceptVersionStrategy,
-      host: acceptHostStrategy
+      host: acceptHostStrategy,
+      negotiationGet: contentNegotiationForGet
     }
 
     this.strategiesInUse = new Set()
@@ -89,6 +91,8 @@ class Constrainer {
           lines.push('   version: req.headers[\'accept-version\'],')
         } else if (key === 'host') {
           lines.push('   host: req.headers.host,')
+        } else if (key === 'negotiationGet') {
+          lines.push('   negotiationGet: req.headers.accept || \'*/*\',')
         } else {
           throw new Error('unknown non-custom strategy for compiling constraint derivation function')
         }

--- a/lib/strategies/content-negotiation/content-negotiation.get.js
+++ b/lib/strategies/content-negotiation/content-negotiation.get.js
@@ -1,0 +1,41 @@
+'use strict'
+const assert = require('assert')
+const Negotiator = require('negotiator')
+
+function ContentNegotiationStore () {
+  let store = {}
+  let mediaTypes = []
+  return {
+    get: (mediaType) => {
+      const negotiator = new Negotiator({ headers: { accept: mediaType } })
+
+      const acceptedMediaType = negotiator.mediaType(mediaTypes)
+
+      return store[acceptedMediaType] || store['406']
+    },
+    set: (mediaType, handler) => {
+      store[mediaType] = handler
+      mediaTypes.push(mediaType)
+    },
+    del: (mediaType) => {
+      delete store[mediaType]
+      mediaTypes = mediaTypes.filter(type => type !== mediaType)
+    },
+    empty: () => {
+      store = {}
+      mediaTypes = []
+    }
+  }
+}
+
+module.exports = {
+  name: 'negotiationGet',
+  mustMatchWhenDerived: true,
+  storage: ContentNegotiationStore,
+  validate (value) {
+    assert(typeof value === 'string', 'Accepted Media Type should be a string.')
+  },
+  deriveConstraint: (req, ctx) => {
+    return req.headers.accept
+  }
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "fast-decode-uri-component": "^1.0.1",
     "fast-deep-equal": "^3.1.3",
+    "negotiator": "^0.6.2",
     "safe-regex2": "^2.0.0",
     "semver-store": "^0.3.0"
   },

--- a/test/constraint.content-negotiation.get.test.js
+++ b/test/constraint.content-negotiation.get.test.js
@@ -1,0 +1,90 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('..')
+const alpha = () => { }
+const beta = () => { }
+const gamma = () => { }
+const delta = () => { }
+
+test('Should return null if no Not Acceptable handler is registered and requested media type is not acceptable', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay({
+    defaultRoute: alpha
+  })
+
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'application/json' } }, beta)
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'application/xml' } }, gamma)
+
+  t.notOk(findMyWay.find('GET', '/', {}))
+  t.notOk(findMyWay.find('GET', '/', { negotiationGet: 'image/png' }))
+})
+
+test('Should return Not Acceptable handler returned if registered and requested media type is not acceptable', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: '406' } }, beta)
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'application/xml' } }, gamma)
+
+  t.strictEqual(findMyWay.find('GET', '/', { negotiationGet: 'image/png' }).handler, beta)
+})
+
+test('Should return exact matching handler', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'image/png' } }, beta)
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'image/jpeg' } }, gamma)
+
+  t.strictEqual(findMyWay.find('GET', '/', { negotiationGet: 'image/png' }).handler, beta)
+  t.strictEqual(findMyWay.find('GET', '/', { negotiationGet: 'image/jpeg' }).handler, gamma)
+})
+
+test('Should return first registered handler if multiple match', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'image/png' } }, beta)
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'image/jpeg' } }, gamma)
+
+  t.strictEqual(findMyWay.find('GET', '/', { negotiationGet: 'image/*' }).handler, beta)
+})
+
+test('Route should support multiple constraints', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'text/plain', version: '1.0.0' } }, alpha)
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'text/plain', version: '2.0.0', host: 'example.com' } }, beta)
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'text/plain', version: '2.0.0', host: 'test.de' } }, gamma)
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'text/plain', version: '2.0.0', host: 'wow.org' } }, delta)
+
+  t.strictEqual(findMyWay.find('GET', '/', { negotiationGet: 'text/*', version: '2.0.x', host: 'test.de' }).handler, gamma)
+})
+
+test('Client accepts any media type if no Accept header is provided', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay({
+    defaultRoute (req, res) {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/', { constraints: { negotiationGet: 'application/json' } }, (req, res) => {
+    t.pass()
+  })
+
+  findMyWay.lookup({
+    method: 'GET',
+    url: '/',
+    headers: {}
+  })
+})


### PR DESCRIPTION
This is still WIP.

The current plan is to write individual contraints for the different HTTP methods. The advantage of this is that the logic of the individual contraints is significantly reduced and should also be more performant.
Currently, `negotiator` is an additional dependency. This could also be removed by documenting that you have to install it yourself when using these constraints. 
I have also given the user the option to register a `406 handler` that will be returned if none of the requested media types are acceptable.

Are you open to this?
