### PR TITLE
fix: fastify issue 3129

### DIFF
--- a/test/fastify-issue-3129.test.js
+++ b/test/fastify-issue-3129.test.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+
+test('contain param and wildcard together', t => {
+  t.plan(4)
+
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '/:lang/item/:id', (req, res, params) => {
+    t.same(params.lang, 'fr')
+    t.same(params.id, '12345')
+  })
+
+  findMyWay.on('GET', '/:lang/item/*', (req, res, params) => {
+    t.same(params.lang, 'fr')
+    t.same(params['*'], '12345/edit')
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/fr/item/12345', headers: {} },
+    null
+  )
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/fr/item/12345/edit', headers: {} },
+    null
+  )
+})


### PR DESCRIPTION
Fixes: https://github.com/fastify/fastify/issues/3129

Before
```
lookup static route x 60,585,458 ops/sec ±0.41% (590 runs sampled)
lookup dynamic route x 3,180,845 ops/sec ±0.34% (592 runs sampled)
lookup dynamic multi-parametric route x 1,888,387 ops/sec ±0.18% (592 runs sampled)
lookup dynamic multi-parametric route with regex x 1,372,640 ops/sec ±0.22% (592 runs sampled)
lookup long static route x 3,070,287 ops/sec ±0.24% (589 runs sampled)
lookup long dynamic route x 2,317,857 ops/sec ±0.30% (590 runs sampled)
lookup static route on constrained router x 17,111,003 ops/sec ±0.80% (570 runs sampled)
lookup static versioned route x 2,786,721 ops/sec ±0.42% (589 runs sampled)
lookup static constrained (version & host) route x 2,759,036 ops/sec ±0.42% (589 runs sampled)
find static route x 41,397,708 ops/sec ±0.51% (572 runs sampled)
find dynamic route x 3,685,946 ops/sec ±0.30% (590 runs sampled)
***find dynamic parametric route with wildcard x 1,856,440 ops/sec ±0.36% (593 runs sampled)***
find dynamic multi-parametric route x 2,057,872 ops/sec ±0.27% (592 runs sampled)
find dynamic multi-parametric route with regex x 1,439,799 ops/sec ±0.26% (591 runs sampled)
find long static route x 4,112,700 ops/sec ±0.27% (591 runs sampled)
find long dynamic route x 2,859,143 ops/sec ±0.21% (593 runs sampled)
find long nested dynamic route x 1,213,767 ops/sec ±0.24% (592 runs sampled)
find long nested dynamic route with other method x 2,362,406 ops/sec ±0.26% (593 runs sampled)
find long nested dynamic route x 1,212,952 ops/sec ±0.22% (593 runs sampled)
find long nested dynamic route with other method x 2,401,196 ops/sec ±0.22% (593 runs sampled)
Done in 668.15s.
```
After
```
lookup static route x 60,103,328 ops/sec ±0.41% (592 runs sampled)
lookup dynamic route x 3,322,131 ops/sec ±0.25% (591 runs sampled)
lookup dynamic multi-parametric route x 1,805,812 ops/sec ±0.60% (590 runs sampled)
lookup dynamic multi-parametric route with regex x 1,359,185 ops/sec ±0.38% (591 runs sampled)
lookup long static route x 3,040,311 ops/sec ±0.32% (588 runs sampled)
lookup long dynamic route x 2,278,720 ops/sec ±0.26% (591 runs sampled)
lookup static route on constrained router x 17,422,556 ops/sec ±0.54% (575 runs sampled)
lookup static versioned route x 2,804,400 ops/sec ±0.23% (592 runs sampled)
lookup static constrained (version & host) route x 2,809,921 ops/sec ±0.18% (593 runs sampled)
find static route x 41,319,116 ops/sec ±0.62% (567 runs sampled)
find dynamic route x 3,652,912 ops/sec ±0.18% (591 runs sampled)
***find dynamic parametric route with wildcard x 1,829,294 ops/sec ±0.28% (593 runs sampled)***
find dynamic multi-parametric route x 2,114,606 ops/sec ±0.27% (593 runs sampled)
find dynamic multi-parametric route with regex x 1,491,503 ops/sec ±0.27% (593 runs sampled)
find long static route x 3,992,056 ops/sec ±0.47% (591 runs sampled)
find long dynamic route x 2,859,343 ops/sec ±0.24% (591 runs sampled)
find long nested dynamic route x 1,242,054 ops/sec ±0.19% (593 runs sampled)
find long nested dynamic route with other method x 2,414,779 ops/sec ±0.21% (593 runs sampled)
find long nested dynamic route x 1,235,653 ops/sec ±0.15% (593 runs sampled)
find long nested dynamic route with other method x 2,411,097 ops/sec ±0.17% (593 runs sampled)
Done in 665.96s.
```