### PR TITLE
Fix mustMatchWhenDerived for route nodes with both unconstrained and constrained routes 

### DIFF
--- a/lib/constrainer.js
+++ b/lib/constrainer.js
@@ -24,6 +24,10 @@ class Constrainer {
         assert(strategy.deriveConstraint && typeof strategy.deriveConstraint === 'function', 'strategy.deriveConstraint function is required.')
         strategy.isCustom = true
         this.strategies[strategy.name] = strategy
+
+        if (strategy.mustMatchWhenDerived) {
+          this.noteUsage({ [kCustomStrategies[i]]: strategy })
+        }
       }
     }
   }

--- a/node.js
+++ b/node.js
@@ -310,7 +310,11 @@ Node.prototype._compileGetHandlerMatchingConstraints = function () {
   }
   // Return the first handler who's bit is set in the candidates https://stackoverflow.com/questions/18134985/how-to-find-index-of-first-set-bit
   lines.push(`
-  return this.handlers[Math.floor(Math.log2(candidates))]
+  const handler = this.handlers[Math.floor(Math.log2(candidates))]
+  if (handler && derivedConstraints.__hasMustMatchValues && handler === this.unconstrainedHandler) {
+    return null;
+  }
+  return handler;
   `)
 
   this._getHandlerMatchingConstraints = new Function('derivedConstraints', lines.join('\n')) // eslint-disable-line

--- a/test/constraint.custom.test.js
+++ b/test/constraint.custom.test.js
@@ -20,7 +20,7 @@ const customHeaderConstraint = {
     }
   },
   deriveConstraint: (req, ctx) => {
-    return req.headers.accept
+    return req.headers['user-agent']
   }
 }
 
@@ -78,4 +78,44 @@ test('A route could support a custom constraint strategy while versioned and hos
   t.notOk(findMyWay.find('GET', '/', { requestedBy: 'curl', version: '2.x' }))
   t.notOk(findMyWay.find('GET', '/', { requestedBy: 'curl', version: '3.x', host: 'fastify.io' }))
   t.notOk(findMyWay.find('GET', '/', { requestedBy: 'curl', version: '1.x', host: 'example.io' }))
+})
+
+test('Custom constraint strategies can set mustMatchWhenDerived flag to true which prevents matches to routes when a constraint is derived', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay({
+    constraints: {
+      requestedBy: {
+        ...customHeaderConstraint,
+        mustMatchWhenDerived: true
+      }
+    },
+    defaultRoute (req, res) {
+      t.pass()
+    }
+  })
+
+  findMyWay.on('GET', '/', {}, () => t.fail())
+
+  findMyWay.lookup({ method: 'GET', url: '/', headers: { 'user-agent': 'node' } }, null)
+})
+
+test('Custom constraint strategies can set mustMatchWhenDerived flag to false which allows matches to unconstrained routes when a constraint is derived', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay({
+    constraints: {
+      requestedBy: {
+        ...customHeaderConstraint,
+        mustMatchWhenDerived: false
+      }
+    },
+    defaultRoute (req, res) {
+      t.fail()
+    }
+  })
+
+  findMyWay.on('GET', '/', {}, () => t.pass())
+
+  findMyWay.lookup({ method: 'GET', url: '/', headers: { 'user-agent': 'node' } }, null)
 })

--- a/test/constraint.default-versioning.test.js
+++ b/test/constraint.default-versioning.test.js
@@ -265,3 +265,26 @@ test('Versioning won\'t work if there are no versioned routes', t => {
     url: '/'
   }, null)
 })
+
+test('Unversioned routes aren\'t triggered when unknown versions are requested', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.ok('We should be here')
+    }
+  })
+
+  findMyWay.on('GET', '/', (req, res) => {
+    t.fail('unversioned route shouldnt be hit!')
+  })
+  findMyWay.on('GET', '/', { constraints: { version: '1.0.0' } }, (req, res) => {
+    t.fail('versioned route shouldnt be hit for wrong version!')
+  })
+
+  findMyWay.lookup({
+    method: 'GET',
+    url: '/',
+    headers: { 'accept-version': '2.x' }
+  }, null)
+})


### PR DESCRIPTION
Fixes #196

mustMatchWhenDerived strategies ensure that requests that pass a value for the constraint (like a version number) should only match routes that are constrained using that strategy. This avoids invoking unconstrained, unversioned routes for requests that are versioned. find-my-way has supported this for a while, but all the work to add custom constraint strategies broke this support in a case where both unconstrained and constrained routes were added for the same path. This fixes the tests to exercise that case and ensures the fast constraint matcher system doesn't allow unconstrained routes to match the mustMatchWhenDerived strategies!

This also fixes a bug where mustMatchWhenDerived constraints need to be used by a route before they start taking effect. 
For these, we need to ensure we always derive a value for the constraint even if no routes are using that constraint yet. That way, we know if the route has a value that must match. This was a bug caused by the performance optimization of trying to avoid deriving constraint values for constraints that aren't in use -- we must consider all custom mustMatchWhenDerived constraints in use in order to check if the value is present.