### PR TITLE
Fix host constraints not working when http2 is enabled

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x, 17.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ In this case you can request `/example/posts` as well as `/example/posts/1`. The
 
 Having a route with multiple parameters may affect negatively the performance, so prefer single parameter approach whenever possible, especially on routes which are on the hot path of your application.
 
+**Note** that you must encode the parameters containing [reserved characters](https://www.rfc-editor.org/rfc/rfc3986#section-2.2).
+
 <a name="match-order"></a>
 ##### Match order
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,12 @@ router.on('GET', '/example/at/:hour(^\\d{2})h:minute(^\\d{2})m', (req, res, para
 ```
 In this case as parameter separator it's possible to use whatever character is not matched by the regular expression.
 
+The last parameter can be made optional if you add a question mark ("?") at the end of the parameters name.
+```js
+router.on('GET', '/example/posts/:id?', (req, res, params) => {}))
+```
+In this case you can request `/example/posts` as well as `/example/posts/1`. The optional param will be undefined if not specified.
+
 Having a route with multiple parameters may affect negatively the performance, so prefer single parameter approach whenever possible, especially on routes which are on the hot path of your application.
 
 <a name="match-order"></a>

--- a/bench.js
+++ b/bench.js
@@ -79,6 +79,12 @@ suite
   .add('find dynamic route', function () {
     findMyWay.find('GET', '/user/tomas', undefined)
   })
+  .add('find dynamic route with encoded parameter unoptimized', function () {
+    findMyWay.find('GET', '/user/maintainer%2Btomas', undefined)
+  })
+  .add('find dynamic route with encoded parameter optimized', function () {
+    findMyWay.find('GET', '/user/maintainer%20tomas', undefined)
+  })
   .add('find dynamic multi-parametric route', function () {
     findMyWay.find('GET', '/customer/john-doe', undefined)
   })
@@ -93,6 +99,12 @@ suite
   })
   .add('find long nested dynamic route', function () {
     findMyWay.find('GET', '/posts/10/comments/42/author', undefined)
+  })
+  .add('find long nested dynamic route with encoded parameter unoptimized', function () {
+    findMyWay.find('GET', '/posts/10%2C10/comments/42%2C42/author', undefined)
+  })
+  .add('find long nested dynamic route with encoded parameter optimized', function () {
+    findMyWay.find('GET', '/posts/10%2510/comments/42%2542/author', undefined)
   })
   .add('find long nested dynamic route with other method', function () {
     findMyWay.find('POST', '/posts/10/comments', undefined)

--- a/lib/constrainer.js
+++ b/lib/constrainer.js
@@ -92,7 +92,7 @@ class Constrainer {
         if (key === 'version') {
           lines.push('   version: req.headers[\'accept-version\'],')
         } else if (key === 'host') {
-          lines.push('   host: req.headers.host,')
+          lines.push('   host: req.headers.host || req.headers[":authority"],')
         } else {
           throw new Error('unknown non-custom strategy for compiling constraint derivation function')
         }

--- a/lib/constrainer.js
+++ b/lib/constrainer.js
@@ -92,7 +92,7 @@ class Constrainer {
         if (key === 'version') {
           lines.push('   version: req.headers[\'accept-version\'],')
         } else if (key === 'host') {
-          lines.push('   host: req.headers.host || req.headers[":authority"],')
+          lines.push('   host: req.headers.host || req.headers[\':authority\'],')
         } else {
           throw new Error('unknown non-custom strategy for compiling constraint derivation function')
         }

--- a/lib/url-sanitizer.js
+++ b/lib/url-sanitizer.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const fastDecode = require('fast-decode-uri-component')
+
+// It must spot all the chars where decodeURIComponent(x) !== decodeURI(x)
+// The chars are: # $ & + , / : ; = ? @
+const uriComponentsCharMap = new Array(53).fill(0x00)
+uriComponentsCharMap[50] = new Array(103).fill(0x00)
+uriComponentsCharMap[50][51] = true // # '%23'
+uriComponentsCharMap[50][52] = true // $ '%24'
+uriComponentsCharMap[50][54] = true // & '%26'
+uriComponentsCharMap[50][66] = true // + '%2B'
+uriComponentsCharMap[50][98] = true // + '%2b'
+uriComponentsCharMap[50][67] = true // , '%2C'
+uriComponentsCharMap[50][99] = true // , '%2c'
+uriComponentsCharMap[50][70] = true // / '%2F'
+uriComponentsCharMap[50][102] = true // / '%2f'
+
+uriComponentsCharMap[51] = new Array(103).fill(0x00)
+uriComponentsCharMap[51][65] = true // : '%3A'
+uriComponentsCharMap[51][97] = true // : '%3a'
+uriComponentsCharMap[51][66] = true // ; '%3B'
+uriComponentsCharMap[51][98] = true // ; '%3b'
+uriComponentsCharMap[51][68] = true // = '%3D'
+uriComponentsCharMap[51][100] = true // = '%3d'
+uriComponentsCharMap[51][70] = true // ? '%3F'
+uriComponentsCharMap[51][102] = true // ? '%3f'
+
+uriComponentsCharMap[52] = new Array(49).fill(0x00)
+uriComponentsCharMap[52][48] = true // @ '%40'
+
+function sanitizeUrl (url) {
+  let originPath = url
+  let shouldDecode = false
+  let containsEncodedComponents = false
+  let highChar
+  let lowChar
+  for (var i = 0, len = url.length; i < len; i++) {
+    var charCode = url.charCodeAt(i)
+
+    if (shouldDecode && !containsEncodedComponents) {
+      if (highChar === 0 && uriComponentsCharMap[charCode]) {
+        highChar = charCode
+        lowChar = 0x00
+      } else if (highChar && lowChar === 0 && uriComponentsCharMap[highChar][charCode]) {
+        containsEncodedComponents = true
+      } else {
+        highChar = undefined
+        lowChar = undefined
+      }
+    }
+
+    // Some systems do not follow RFC and separate the path and query
+    // string with a `;` character (code 59), e.g. `/foo;jsessionid=123456`.
+    // Thus, we need to split on `;` as well as `?` and `#`.
+    if (charCode === 63 || charCode === 59 || charCode === 35) {
+      originPath = url.slice(0, i)
+      break
+    } else if (charCode === 37) {
+      shouldDecode = true
+      highChar = 0x00
+    }
+  }
+  const decoded = shouldDecode ? decodeURI(originPath) : originPath
+
+  return {
+    path: decoded,
+    originPath,
+    sliceParameter: containsEncodedComponents
+      ? sliceAndDecode
+      : slicePath
+  }
+}
+
+module.exports = sanitizeUrl
+
+function sliceAndDecode (from, to) {
+  return fastDecode(this.originPath.slice(from, to))
+}
+
+function slicePath (from, to) {
+  return this.path.slice(from, to)
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-my-way",
-  "version": "4.3.3",
+  "version": "4.4.0",
   "description": "Crazy fast http radix based router",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/anker2000/find-my-way.git"
+    "url": "git+https://github.com/delvedor/find-my-way.git"
   },
   "keywords": [
     "http",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "speed"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-my-way",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "description": "Crazy fast http radix based router",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/delvedor/find-my-way.git"
+    "url": "git+https://github.com/anker2000/find-my-way.git"
   },
   "keywords": [
     "http",

--- a/test/issue-206.test.js
+++ b/test/issue-206.test.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('..')
+
+test('Decode the URL before the routing', t => {
+  t.plan(8)
+  const findMyWay = FindMyWay()
+
+  function space (req, res, params) {}
+  function percentTwenty (req, res, params) {}
+  function percentTwentyfive (req, res, params) {}
+
+  findMyWay.on('GET', '/static/:pathParam', () => {})
+  findMyWay.on('GET', '/[...]/a .html', space)
+  findMyWay.on('GET', '/[...]/a%20.html', percentTwenty)
+  findMyWay.on('GET', '/[...]/a%2520.html', percentTwentyfive)
+
+  t.equal(findMyWay.find('GET', '/[...]/a .html').handler, space)
+  t.equal(findMyWay.find('GET', '/%5B...%5D/a .html').handler, space)
+  t.equal(findMyWay.find('GET', '/[...]/a%20.html').handler, space, 'a%20 decode is a ')
+  t.equal(findMyWay.find('GET', '/%5B...%5D/a%20.html').handler, space, 'a%20 decode is a ')
+  t.equal(findMyWay.find('GET', '/[...]/a%2520.html').handler, percentTwenty, 'a%2520 decode is a%20')
+  t.equal(findMyWay.find('GET', '/%5B...%5D/a%252520.html').handler, percentTwentyfive, 'a%252520.html is a%2520')
+  t.equal(findMyWay.find('GET', '/[...]/a  .html'), null, 'double space')
+  t.equal(findMyWay.find('GET', '/static/%25E0%A4%A'), null, 'invalid encoded path param')
+})
+
+test('double encoding', t => {
+  t.plan(8)
+  const findMyWay = FindMyWay()
+
+  function pathParam (req, res, params) {
+    t.same(params, this.expect, 'path param')
+    t.same(pathParam, this.handler, 'match handler')
+  }
+  function regexPathParam (req, res, params) {
+    t.same(params, this.expect, 'regex param')
+    t.same(regexPathParam, this.handler, 'match handler')
+  }
+  function wildcard (req, res, params) {
+    t.same(params, this.expect, 'wildcard param')
+    t.same(wildcard, this.handler, 'match handler')
+  }
+
+  findMyWay.on('GET', '/:pathParam', pathParam)
+  findMyWay.on('GET', '/reg/:regExeParam(^.*$)', regexPathParam)
+  findMyWay.on('GET', '/wild/*', wildcard)
+
+  findMyWay.lookup(get('/' + doubleEncode('reg/hash# .png')), null,
+    { expect: { pathParam: singleEncode('reg/hash# .png') }, handler: pathParam }
+  )
+  findMyWay.lookup(get('/' + doubleEncode('special # $ & + , / : ; = ? @')), null,
+    { expect: { pathParam: singleEncode('special # $ & + , / : ; = ? @') }, handler: pathParam }
+  )
+  findMyWay.lookup(get('/reg/' + doubleEncode('hash# .png')), null,
+    { expect: { regExeParam: singleEncode('hash# .png') }, handler: regexPathParam }
+  )
+  findMyWay.lookup(get('/wild/' + doubleEncode('mail@mail.it')), null,
+    { expect: { '*': singleEncode('mail@mail.it') }, handler: wildcard }
+  )
+
+  function doubleEncode (str) {
+    return encodeURIComponent(encodeURIComponent(str))
+  }
+  function singleEncode (str) {
+    return encodeURIComponent(str)
+  }
+})
+
+test('Special chars on path parameter', t => {
+  t.plan(10)
+  const findMyWay = FindMyWay()
+
+  function pathParam (req, res, params) {
+    t.same(params, this.expect, 'path param')
+    t.same(pathParam, this.handler, 'match handler')
+  }
+  function regexPathParam (req, res, params) {
+    t.same(params, this.expect, 'regex param')
+    t.same(regexPathParam, this.handler, 'match handler')
+  }
+  function staticEncoded (req, res, params) {
+    t.same(params, this.expect, 'static match')
+    t.same(staticEncoded, this.handler, 'match handler')
+  }
+
+  findMyWay.on('GET', '/:pathParam', pathParam)
+  findMyWay.on('GET', '/reg/:regExeParam(^\\d+) .png', regexPathParam)
+  findMyWay.on('GET', '/[...]/a%2520.html', staticEncoded)
+
+  findMyWay.lookup(get('/%5B...%5D/a%252520.html'), null, { expect: {}, handler: staticEncoded })
+  findMyWay.lookup(get('/[...].html'), null, { expect: { pathParam: '[...].html' }, handler: pathParam })
+  findMyWay.lookup(get('/reg/123 .png'), null, { expect: { regExeParam: '123' }, handler: regexPathParam })
+  findMyWay.lookup(get('/reg%2F123 .png'), null, { expect: { pathParam: 'reg/123 .png' }, handler: pathParam }) // en encoded / is considered a parameter
+  findMyWay.lookup(get('/reg/123%20.png'), null, { expect: { regExeParam: '123' }, handler: regexPathParam })
+})
+
+function get (url) {
+  return { method: 'GET', url, headers: {} }
+}
+
+// http://localhost:3000/parameter with / in it
+// http://localhost:3000/parameter%20with%20%2F%20in%20it
+
+// http://localhost:3000/parameter with %252F in it

--- a/test/on-bad-url.test.js
+++ b/test/on-bad-url.test.js
@@ -11,7 +11,7 @@ test('If onBadUrl is defined, then a bad url should be handled differently (find
       t.fail('Should not be defaultRoute')
     },
     onBadUrl: (path, req, res) => {
-      t.equal(path, '/%world')
+      t.equal(path, '/%world', { todo: 'this is not executed' })
     }
   })
 
@@ -30,7 +30,7 @@ test('If onBadUrl is defined, then a bad url should be handled differently (look
       t.fail('Should not be defaultRoute')
     },
     onBadUrl: (path, req, res) => {
-      t.equal(path, '%world')
+      t.equal(path, '/hello/%world')
     }
   })
 

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -1,0 +1,145 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+
+test('Test route with optional parameter', (t) => {
+  t.plan(2)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/a/:param/b/:optional?', (req, res, params) => {
+    if (params.optional) {
+      t.equal(params.optional, 'foo')
+    } else {
+      t.equal(params.optional, undefined)
+    }
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/a/foo-bar/b', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/a/foo-bar/b/foo', headers: {} }, null)
+})
+
+test('Test for duplicate route with optional param', (t) => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/foo/:bar?', (req, res, params) => {})
+
+  try {
+    findMyWay.on('GET', '/foo', (req, res, params) => {})
+    t.fail('method is already declared for route with optional param')
+  } catch (e) {
+    t.equal(e.message, 'Method \'GET\' already declared for route \'/foo\' with constraints \'{}\'')
+  }
+})
+
+test('Test for param with ? not at the end', (t) => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  try {
+    findMyWay.on('GET', '/foo/:bar?/baz', (req, res, params) => {})
+    t.fail('Optional Param in the middle of the path is not allowed')
+  } catch (e) {
+    t.equal(e.message, 'Optional Parameter needs to be the last parameter of the path')
+  }
+})
+
+test('Multi parametric route with optional param', (t) => {
+  t.plan(2)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/a/:p1-:p2?', (req, res, params) => {
+    if (params.p1 && params.p2) {
+      t.equal(params.p1, 'foo')
+      t.equal(params.p2, 'bar-baz')
+    }
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/a/foo-bar-baz', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/a', headers: {} }, null)
+})
+
+test('Optional Parameter with ignoreTrailingSlash = true', (t) => {
+  t.plan(4)
+  const findMyWay = FindMyWay({
+    ignoreTrailingSlash: true,
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/test/hello/:optional?', (req, res, params) => {
+    if (params.optional) {
+      t.equal(params.optional, 'foo')
+    } else {
+      t.equal(params.optional, undefined)
+    }
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/foo', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/foo/', headers: {} }, null)
+})
+
+test('Optional Parameter with ignoreTrailingSlash = false', (t) => {
+  t.plan(4)
+  const findMyWay = FindMyWay({
+    ignoreTrailingSlash: false,
+    defaultRoute: (req, res) => {
+      t.match(req.url, '/test/hello/foo/')
+    }
+  })
+
+  findMyWay.on('GET', '/test/hello/:optional?', (req, res, params) => {
+    if (req.url === '/test/hello/') {
+      t.same(params, { optional: '' })
+    } else if (req.url === '/test/hello') {
+      t.same(params, {})
+    } else if (req.url === '/test/hello/foo') {
+      t.same(params, { optional: 'foo' })
+    }
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/foo', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/test/hello/foo/', headers: {} }, null)
+})
+
+test('derigister a route with optional param', (t) => {
+  t.plan(4)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('Should not be defaultRoute')
+    }
+  })
+
+  findMyWay.on('GET', '/a/:param/b/:optional?', (req, res, params) => {})
+
+  t.ok(findMyWay.find('GET', '/a/:param/b'))
+  t.ok(findMyWay.find('GET', '/a/:param/b/:optional'))
+
+  findMyWay.off('GET', '/a/:param/b/:optional?')
+
+  t.notOk(findMyWay.find('GET', '/a/:param/b'))
+  t.notOk(findMyWay.find('GET', '/a/:param/b/:optional'))
+})


### PR DESCRIPTION
Find-my-way is relying on req.headers.host to determine the host, however when http2 is enabled req.headers.host won't return the host name. For http2 req.headers[':authority'] could be used.