### PR TITLE
fix: parametric brother path extraction (#222)

### DIFF
--- a/custom_node.js
+++ b/custom_node.js
@@ -76,6 +76,7 @@ Node.prototype._saveParametricBrother = function () {
   let parametricBrother = this.parametricBrother
   for (const child of Object.values(this.children)) {
     if (child.prefix === ':') {
+      child.parametricBrother = parametricBrother
       parametricBrother = child
       break
     }
@@ -84,7 +85,7 @@ Node.prototype._saveParametricBrother = function () {
   // Save the parametric brother inside static children
   if (parametricBrother) {
     for (const child of Object.values(this.children)) {
-      if (child && child.kind === this.types.STATIC) {
+      if (child && child !== parametricBrother) {
         child.parametricBrother = parametricBrother
         child._saveParametricBrother(parametricBrother)
       }
@@ -143,7 +144,7 @@ Node.prototype.findMatchingChild = function (derivedConstraints, path) {
   }
 
   child = this.children[':']
-  if (child !== undefined && (child.numberOfChildren > 0 || child.getMatchingHandler(derivedConstraints) !== null)) {
+  if (child !== undefined && path[0] !== ':' && (child.numberOfChildren > 0 || child.getMatchingHandler(derivedConstraints) !== null)) {
     return child
   }
 

--- a/test/issue-221.test.js
+++ b/test/issue-221.test.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('..')
+
+test('Should return correct param after switching from static route', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/prefix-:id', () => {})
+  findMyWay.on('GET', '/prefix-111', () => {})
+
+  t.same(findMyWay.find('GET', '/prefix-1111').params, { id: '1111' })
+})
+
+test('Should return correct param after switching from static route', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/prefix-111', () => {})
+  findMyWay.on('GET', '/prefix-:id/hello', () => {})
+
+  t.same(findMyWay.find('GET', '/prefix-1111/hello').params, { id: '1111' })
+})
+
+test('Should return correct param after switching from parametric route', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/prefix-111', () => {})
+  findMyWay.on('GET', '/prefix-:id/hello', () => {})
+  findMyWay.on('GET', '/:id', () => {})
+
+  t.same(findMyWay.find('GET', '/prefix-1111-hello').params, { id: 'prefix-1111-hello' })
+})
+
+test('Should return correct params after switching from parametric route', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/test/:param1/test/:param2/prefix-111', () => {})
+  findMyWay.on('GET', '/test/:param1/test/:param2/prefix-:id/hello', () => {})
+  findMyWay.on('GET', '/test/:param1/test/:param2/:id', () => {})
+
+  t.same(findMyWay.find('GET', '/test/value1/test/value2/prefix-1111-hello').params, {
+    param1: 'value1',
+    param2: 'value2',
+    id: 'prefix-1111-hello'
+  })
+})


### PR DESCRIPTION
The problem was that after switching from static route to parametric brother route it was trying to restore the previous path by searching the last `/` symbol. It means that if I have two routes `/static-test` and `/static-:param` and if I try to find `/static-test1`, after failing with static route it will stitch to parametric route and pass `static-test1` as a param instead of `test1`.

I fixed it by creating a stack where I put the context (the current position in the path and the parameters already found) every time I meet a node that has a parametric brother. When I need to switch to a parametric brother route I just get a context from the top of the stack.

Another thing that I changed here is that I added a parametric brother route not only for static routes but for all routes.