### PR TITLE
change path for short static route bench

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -15,6 +15,7 @@ const FindMyWay = require('./')
 
 const findMyWay = new FindMyWay()
 findMyWay.on('GET', '/', () => true)
+findMyWay.on('GET', '/a', () => true)
 findMyWay.on('GET', '/user/:id', () => true)
 findMyWay.on('GET', '/user/:id/static', () => true)
 findMyWay.on('POST', '/user/:id', () => true)
@@ -46,8 +47,11 @@ constrained.on('GET', '/versioned', { constraints: { version: '2.0.0', host: 'ex
 constrained.on('GET', '/versioned', { constraints: { version: '2.0.0', host: 'fastify.io' } }, () => true)
 
 suite
-  .add('lookup static route', function () {
+  .add('lookup root "/" route', function () {
     findMyWay.lookup({ method: 'GET', url: '/', headers: { host: 'fastify.io' } }, null)
+  })
+  .add('lookup static route', function () {
+    findMyWay.lookup({ method: 'GET', url: '/a', headers: { host: 'fastify.io' } }, null)
   })
   .add('lookup dynamic route', function () {
     findMyWay.lookup({ method: 'GET', url: '/user/tomas', headers: { host: 'fastify.io' } }, null)
@@ -73,8 +77,11 @@ suite
   .add('lookup static constrained (version & host) route', function () {
     constrained.lookup({ method: 'GET', url: '/versioned', headers: { 'accept-version': '2.x', host: 'fastify.io' } }, null)
   })
-  .add('find static route', function () {
+  .add('find root "/" route', function () {
     findMyWay.find('GET', '/', undefined)
+  })
+  .add('find static route', function () {
+    findMyWay.find('GET', '/a', undefined)
   })
   .add('find dynamic route', function () {
     findMyWay.find('GET', '/user/tomas', undefined)


### PR DESCRIPTION
When I tried to optimize the find method, I was confused. I made changes that were supposed to speed up the algorithm, but they only made it slower for short static routes. It turns out that `/` route is a super special case, cause you get the results immediately from the root node without using the searching algorithm. If you try to search the path that contains only one more symbol `/a`, you will get at least twice a worse result. IMHO, when we test the find method we want to see results for some average, but not for the extreme case.