### PR TITLE
Added maps for static routes

### DIFF
--- a/custom_node.js
+++ b/custom_node.js
@@ -135,16 +135,24 @@ Node.prototype.findByLabel = function (path) {
   return this.children[path[0]]
 }
 
-Node.prototype.findMatchingChild = function (derivedConstraints, path) {
-  var child = this.children[path[0]]
+Node.prototype.findMatchingChild = function (derivedConstraints, path, pathIndex) {
+  var child = this.children[path[pathIndex]]
   if (child !== undefined && (child.numberOfChildren > 0 || child.getMatchingHandler(derivedConstraints) !== null)) {
-    if (path.slice(0, child.prefix.length) === child.prefix) {
+    let isPathStartsWithPrefix = true
+    for (let i = 0; i < child.prefix.length; i++) {
+      if (path.charCodeAt(pathIndex + i) !== child.prefix.charCodeAt(i)) {
+        isPathStartsWithPrefix = false
+        break
+      }
+    }
+
+    if (isPathStartsWithPrefix) {
       return child
     }
   }
 
-  child = this.children[':']
-  if (child !== undefined && path[0] !== ':' && (child.numberOfChildren > 0 || child.getMatchingHandler(derivedConstraints) !== null)) {
+  child = path[pathIndex] !== ':' ? this.children[':'] : undefined
+  if (child !== undefined && (child.numberOfChildren > 0 || child.getMatchingHandler(derivedConstraints) !== null)) {
     return child
   }
 

--- a/custom_node.js
+++ b/custom_node.js
@@ -24,6 +24,7 @@ function Node (options) {
   this.kind = options.kind || this.types.STATIC
   this.regex = options.regex || null
   this.wildcardChild = null
+  this.parametricChild = null
   this.parametricBrother = null
   this.constrainer = options.constrainer
   this.hasConstraints = options.hasConstraints || false
@@ -34,19 +35,16 @@ Object.defineProperty(Node.prototype, 'types', {
   value: types
 })
 
-Node.prototype.getLabel = function () {
-  return this.prefix[0]
-}
-
 Node.prototype.addChild = function (node) {
   var label = ''
   switch (node.kind) {
     case this.types.STATIC:
-      label = node.getLabel()
+      label = node.prefix[0]
       break
     case this.types.PARAM:
     case this.types.REGEX:
     case this.types.MULTI_PARAM:
+      this.parametricChild = node
       label = ':'
       break
     case this.types.MATCH_ALL:
@@ -63,9 +61,7 @@ Node.prototype.addChild = function (node) {
   )
 
   this.children[label] = node
-
-  const nodeChildren = Object.values(this.children)
-  this.numberOfChildren = nodeChildren.length
+  this.numberOfChildren++
 
   this._saveParametricBrother()
 
@@ -74,12 +70,9 @@ Node.prototype.addChild = function (node) {
 
 Node.prototype._saveParametricBrother = function () {
   let parametricBrother = this.parametricBrother
-  for (const child of Object.values(this.children)) {
-    if (child.prefix === ':') {
-      child.parametricBrother = parametricBrother
-      parametricBrother = child
-      break
-    }
+  if (this.parametricChild !== null) {
+    this.parametricChild.parametricBrother = parametricBrother
+    parametricBrother = this.parametricChild
   }
 
   // Save the parametric brother inside static children
@@ -102,6 +95,7 @@ Node.prototype.reset = function (prefix) {
   this.numberOfChildren = 0
   this.regex = null
   this.wildcardChild = null
+  this.parametricChild = null
   this.hasConstraints = false
   this._decompileGetHandlerMatchingConstraints()
   return this
@@ -124,6 +118,10 @@ Node.prototype.split = function (length) {
 
   if (this.wildcardChild !== null) {
     newChild.wildcardChild = this.wildcardChild
+  }
+
+  if (this.parametricChild !== null) {
+    newChild.parametricChild = this.parametricChild
   }
 
   this.reset(this.prefix.slice(0, length))
@@ -151,13 +149,13 @@ Node.prototype.findMatchingChild = function (derivedConstraints, path, pathIndex
     }
   }
 
-  child = path[pathIndex] !== ':' ? this.children[':'] : undefined
-  if (child !== undefined) {
+  child = this.parametricChild
+  if (child !== null) {
     return child
   }
 
-  child = this.children['*']
-  if (child !== undefined) {
+  child = this.wildcardChild
+  if (child !== null) {
     return child
   }
 

--- a/index.js
+++ b/index.js
@@ -432,9 +432,7 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
   while (true) {
     // found the route
     if (pathIndex === pathLen) {
-      const handle = derivedConstraints !== undefined
-        ? currentNode.getMatchingHandler(derivedConstraints)
-        : currentNode.unconstrainedHandler
+      const handle = currentNode.getMatchingHandler(derivedConstraints)
 
       if (handle !== null && handle !== undefined) {
         const paramsObj = {}
@@ -557,7 +555,7 @@ Router.prototype._getWildcardNode = function (node, sanitizedUrl, len, derivedCo
     return this._onBadUrl(sanitizedUrl.slice(len))
   }
 
-  var handle = derivedConstraints !== undefined ? node.getMatchingHandler(derivedConstraints) : node.unconstrainedHandler
+  var handle = node.getMatchingHandler(derivedConstraints)
 
   if (handle !== null && handle !== undefined) {
     var paramsObj = {}

--- a/index.js
+++ b/index.js
@@ -426,7 +426,6 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
   let wildcardNode = null
   let wildcardNodePathIndex = 0
 
-  let lastParametricBrother = null
   const parametricBrothersStack = []
 
   while (true) {
@@ -465,14 +464,12 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
       params.splice(paramsCount)
     } else if (
       pathIndex < pathLen &&
-      node.parametricBrother !== null &&
-      node.parametricBrother !== lastParametricBrother
+      currentNode.parametricChild !== null
     ) {
       parametricBrothersStack.push({
         brotherPathIndex: pathIndex,
         paramsCount: params.length
       })
-      lastParametricBrother = node.parametricBrother
     }
 
     // if exist, save the wildcard child

--- a/index.js
+++ b/index.js
@@ -423,10 +423,8 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
   const params = []
   const pathLen = path.length
 
-  let wildcardNode = null
-  let wildcardNodePathIndex = 0
-
   const parametricBrothersStack = []
+  const wildcardBrothersStack = []
 
   while (true) {
     // found the route
@@ -451,31 +449,45 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
       }
     }
 
-    let node = currentNode.findMatchingChild(derivedConstraints, path, pathIndex)
+    let node = currentNode.findStaticMatchingChild(path, pathIndex)
 
-    if (node === null) {
-      node = currentNode.parametricBrother
+    if (currentNode.parametricChild !== null) {
       if (node === null) {
-        return this._getWildcardNode(wildcardNode, path, wildcardNodePathIndex, derivedConstraints, params)
+        node = currentNode.parametricChild
+      } else {
+        parametricBrothersStack.push({
+          brotherPathIndex: pathIndex,
+          paramsCount: params.length
+        })
       }
-
-      const { brotherPathIndex, paramsCount } = parametricBrothersStack.pop()
-      pathIndex = brotherPathIndex
-      params.splice(paramsCount)
-    } else if (
-      pathIndex < pathLen &&
-      currentNode.parametricChild !== null
-    ) {
-      parametricBrothersStack.push({
-        brotherPathIndex: pathIndex,
-        paramsCount: params.length
-      })
     }
 
-    // if exist, save the wildcard child
     if (currentNode.wildcardChild !== null) {
-      wildcardNode = currentNode.wildcardChild
-      wildcardNodePathIndex = pathIndex
+      if (node === null) {
+        node = currentNode.wildcardChild
+      } else {
+        wildcardBrothersStack.push({
+          brotherPathIndex: pathIndex,
+          paramsCount: params.length
+        })
+      }
+    }
+
+    if (node === null) {
+      let brotherNodeState
+      node = currentNode.parametricBrother
+      if (node === null) {
+        node = currentNode.wildcardBrother
+        if (node === null) {
+          return null
+        }
+        brotherNodeState = wildcardBrothersStack.pop()
+      } else {
+        brotherNodeState = parametricBrothersStack.pop()
+      }
+
+      pathIndex = brotherNodeState.brotherPathIndex
+      params.splice(brotherNodeState.paramsCount)
     }
 
     currentNode = node
@@ -543,37 +555,6 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
     params.push(decoded)
     pathIndex = paramEndIndex
   }
-}
-
-Router.prototype._getWildcardNode = function (node, sanitizedUrl, len, derivedConstraints, params) {
-  if (node === null) return null
-  var decoded = sanitizedUrl.slice(len)
-  if (decoded === null) {
-    return this._onBadUrl(sanitizedUrl.slice(len))
-  }
-
-  var handle = node.getMatchingHandler(derivedConstraints)
-
-  if (handle !== null && handle !== undefined) {
-    var paramsObj = {}
-    if (handle.paramsLength > 0 && params !== null) {
-      var paramNames = handle.params
-
-      for (i = 0; i < handle.paramsLength; i++) {
-        paramsObj[paramNames[i]] = params[i]
-      }
-    }
-
-    // we must override params[*] to decoded
-    paramsObj['*'] = decoded
-
-    return {
-      handler: handle.handler,
-      params: paramsObj,
-      store: handle.store
-    }
-  }
-  return null
 }
 
 Router.prototype._defaultRoute = function (req, res, ctx) {

--- a/test/issue-28.test.js
+++ b/test/issue-28.test.js
@@ -575,3 +575,29 @@ test('Nested wildcards with parametric and static - 8', t => {
     null
   )
 })
+
+test('Wildcard node with constraints', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.equal(params['*'], '/foo1/foo3')
+  })
+
+  findMyWay.on('GET', '/foo1/*', { constraints: { host: 'fastify.io' } }, (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.on('GET', '/foo1/foo2', (req, res, params) => {
+    t.fail('we should not be here, the url is: ' + req.url)
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/foo1/foo3', headers: {} },
+    null
+  )
+})


### PR DESCRIPTION
The main idea is to add maps (Map<path, endpointNode>) for static routes. It should make them super fast, as we can get them for constant time without going through the tree.

With these changes, the long static bench speed increased more than 125% and it hasn't a lot of sub-nodes on its path that can split it. The more node you have, the slower your search is. But with the map, you will have always fast constant time results.

It's not the final version, I just want to hear your thoughts about it

See only the last commit.