### PR TITLE
Fixed parameters parsing

### DIFF
--- a/custom_node.js
+++ b/custom_node.js
@@ -7,9 +7,7 @@ const types = {
   STATIC: 0,
   PARAM: 1,
   MATCH_ALL: 2,
-  REGEX: 3,
-  // It's used for a parameter, that is followed by another parameter in the same part
-  MULTI_PARAM: 4
+  REGEX: 3
 }
 
 function Node (options) {
@@ -158,7 +156,6 @@ Node.prototype.getChildByLabel = function (label, kind) {
       return this.wildcardChild
     case this.types.PARAM:
     case this.types.REGEX:
-    case this.types.MULTI_PARAM:
       return this.parametricChild
   }
 }

--- a/custom_node.js
+++ b/custom_node.js
@@ -46,7 +46,6 @@ Node.prototype.addChild = function (node) {
       break
     case this.types.PARAM:
     case this.types.REGEX:
-    case this.types.MULTI_PARAM:
       assert(this.parametricChild === null, 'There is already a parametric child')
       this.parametricChild = node
       break

--- a/custom_node.js
+++ b/custom_node.js
@@ -146,6 +146,23 @@ Node.prototype.split = function (length) {
   return newChild
 }
 
+Node.prototype.getChildByLabel = function (label, kind) {
+  if (label.length === 0) {
+    return null
+  }
+
+  switch (kind) {
+    case this.types.STATIC:
+      return this.staticChildren[label]
+    case this.types.MATCH_ALL:
+      return this.wildcardChild
+    case this.types.PARAM:
+    case this.types.REGEX:
+    case this.types.MULTI_PARAM:
+      return this.parametricChild
+  }
+}
+
 Node.prototype.findStaticMatchingChild = function (path, pathIndex) {
   const child = this.staticChildren[path[pathIndex]]
   if (child !== undefined) {

--- a/index.js
+++ b/index.js
@@ -115,25 +115,25 @@ Router.prototype.on = function on (method, path, opts, handler, store) {
     return
   }
 
-  this._on(method, path, opts, handler, store)
+  const methods = Array.isArray(method) ? method : [method]
+  const paths = [path]
 
   if (this.ignoreTrailingSlash && path !== '/' && !path.endsWith('*')) {
     if (path.endsWith('/')) {
-      this._on(method, path.slice(0, -1), opts, handler, store)
+      paths.push(path.slice(0, -1))
     } else {
-      this._on(method, path + '/', opts, handler, store)
+      paths.push(path + '/')
+    }
+  }
+
+  for (const path of paths) {
+    for (const method of methods) {
+      this._on(method, path, opts, handler, store)
     }
   }
 }
 
 Router.prototype._on = function _on (method, path, opts, handler, store) {
-  if (Array.isArray(method)) {
-    for (const m of method) {
-      this._on(m, path, opts, handler, store)
-    }
-    return
-  }
-
   assert(typeof method === 'string', 'Method should be a string')
   assert(httpMethods.includes(method), `Method '${method}' is not an http method.`)
 

--- a/index.js
+++ b/index.js
@@ -128,14 +128,14 @@ Router.prototype.on = function on (method, path, opts, handler, store) {
 
 Router.prototype._on = function _on (method, path, opts, handler, store) {
   if (Array.isArray(method)) {
-    for (var k = 0; k < method.length; k++) {
-      this._on(method[k], path, opts, handler, store)
+    for (const m of method) {
+      this._on(m, path, opts, handler, store)
     }
     return
   }
 
   assert(typeof method === 'string', 'Method should be a string')
-  assert(httpMethods.indexOf(method) !== -1, `Method '${method}' is not an http method.`)
+  assert(httpMethods.includes(method), `Method '${method}' is not an http method.`)
 
   let constraints = {}
   if (opts.constraints !== undefined) {
@@ -150,39 +150,41 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
   this.constrainer.noteUsage(constraints)
 
   const params = []
-  var j = 0
+  let j = 0
 
-  this.routes.push({
-    method: method,
-    path: path,
-    opts: opts,
-    handler: handler,
-    store: store
-  })
+  this.routes.push({ method, path, opts, handler, store })
 
-  for (var i = 0, len = path.length; i < len; i++) {
+  // Boot the tree for this method if it doesn't exist yet
+  let currentNode = this.trees[method]
+  if (typeof currentNode === 'undefined') {
+    currentNode = new Node({ method: method, constrainer: this.constrainer })
+    this.trees[method] = currentNode
+  }
+
+  if (!path.startsWith('/') && currentNode.prefix !== '') {
+    currentNode.split(0)
+  }
+
+  let lastPathIndex = this.trees[method].prefix.length
+
+  for (let i = 0, len = path.length; i <= len; i++) {
     // search for parametric or wildcard routes
     // parametric route
     if (path.charCodeAt(i) === 58) {
       if (i !== len - 1 && path.charCodeAt(i + 1) === 58) {
         // It's a double colon. Let's just skip it with and go ahead
-        i += 2
+        path = path.slice(0, i) + path.slice(i + 1)
         continue
       }
 
-      var nodeType = NODE_TYPES.PARAM
+      let nodeType = NODE_TYPES.PARAM
       j = i + 1
-      var staticPart = path.slice(0, i)
-
-      if (this.caseSensitive === false) {
-        staticPart = staticPart.toLowerCase()
-      }
 
       // add the static part of the route to the tree
-      this._insert(method, staticPart, NODE_TYPES.STATIC, null, null, null, null, constraints)
+      currentNode = this._insert(currentNode, method, path.slice(lastPathIndex, i), NODE_TYPES.STATIC, null)
 
       // isolate the parameter name
-      var isRegex = false
+      let isRegex = false
       while (i < len && path.charCodeAt(i) !== 47) {
         isRegex = isRegex || path[i] === '('
         if (isRegex) {
@@ -201,8 +203,8 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
         nodeType = NODE_TYPES.MULTI_PARAM
       }
 
-      var parameter = path.slice(j, i)
-      var regex = isRegex ? parameter.slice(parameter.indexOf('('), i) : null
+      const parameter = path.slice(j, i)
+      let regex = isRegex ? parameter.slice(parameter.indexOf('('), i) : null
       if (isRegex) {
         regex = new RegExp(regex)
         if (!this.allowUnsafeRegex) {
@@ -215,131 +217,54 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
       i = j
       len = path.length
 
-      // if the path is ended
-      if (i === len) {
-        var completedPath = path.slice(0, i)
-        if (this.caseSensitive === false) {
-          completedPath = completedPath.toLowerCase()
-        }
-        return this._insert(method, completedPath, nodeType, params, handler, store, regex, constraints)
-      }
-      // add the parameter and continue with the search
-      staticPart = path.slice(0, i)
-      if (this.caseSensitive === false) {
-        staticPart = staticPart.toLowerCase()
-      }
-      this._insert(method, staticPart, nodeType, params, null, null, regex, constraints)
+      currentNode = this._insert(currentNode, method, ':', nodeType, regex)
 
-      i--
+      if (i < len) {
+        lastPathIndex = i--
+      }
     // wildcard route
     } else if (path.charCodeAt(i) === 42) {
-      this._insert(method, path.slice(0, i), NODE_TYPES.STATIC, null, null, null, null, constraints)
+      currentNode = this._insert(currentNode, method, path.slice(lastPathIndex, i), NODE_TYPES.STATIC, null)
       // add the wildcard parameter
       params.push('*')
-      return this._insert(method, path.slice(0, len), NODE_TYPES.MATCH_ALL, params, handler, store, null, constraints)
+      currentNode = this._insert(currentNode, method, path.slice(i, len), NODE_TYPES.MATCH_ALL, null)
+      break
+    } else if (i === len) {
+      currentNode = this._insert(currentNode, method, path.slice(lastPathIndex), NODE_TYPES.STATIC, null)
     }
   }
 
-  if (this.caseSensitive === false) {
+  assert(!currentNode.getHandler(constraints), `Method '${method}' already declared for route '${path}' with constraints '${JSON.stringify(constraints)}'`)
+  currentNode.addHandler(handler, params, store, constraints)
+}
+
+Router.prototype._insert = function _insert (currentNode, method, path, kind, regex) {
+  if (!this.caseSensitive) {
     path = path.toLowerCase()
   }
 
-  // static route
-  this._insert(method, path, NODE_TYPES.STATIC, params, handler, store, null, constraints)
-}
+  let childNode = currentNode.getChildByLabel(path.charAt(0), kind)
+  while (childNode) {
+    currentNode = childNode
 
-Router.prototype._insert = function _insert (method, path, kind, params, handler, store, regex, constraints) {
-  const route = path
-  var node = null
-
-  // Boot the tree for this method if it doesn't exist yet
-  var currentNode = this.trees[method]
-  if (typeof currentNode === 'undefined') {
-    currentNode = new Node({ method: method, constrainer: this.constrainer })
-    this.trees[method] = currentNode
-  }
-
-  while (true) {
-    const prefix = currentNode.prefix
-    let len = 0
-
-    // search for the longest common prefix
-    for (; len < Math.min(path.length, prefix.length); len++) {
-      if (path.charCodeAt(len) === 58 && path.charCodeAt(len + 1) === 58) {
-        path = path.slice(0, len) + path.slice(len + 1)
-      }
-
-      if (path[len] !== prefix[len]) {
+    let i = 0
+    for (; i < currentNode.prefix.length; i++) {
+      if (path.charCodeAt(i) !== currentNode.prefix.charCodeAt(i)) {
+        currentNode.split(i)
         break
       }
     }
-
-    // the longest common prefix is smaller than the current prefix
-    // let's split the node and add a new child
-    if (len < prefix.length) {
-      node = currentNode.split(len)
-
-      // if the longest common prefix has the same length of the current path
-      // the handler should be added to the current node, to a child otherwise
-      if (len === path.length) {
-        assert(!currentNode.getHandler(constraints), `Method '${method}' already declared for route '${route}' with constraints '${JSON.stringify(constraints)}'`)
-        currentNode.addHandler(handler, params, store, constraints)
-        currentNode.kind = kind
-      } else {
-        node = new Node({
-          method: method,
-          prefix: path.slice(len),
-          kind: kind,
-          handlers: null,
-          regex: regex,
-          constrainer: this.constrainer
-        })
-        node.addHandler(handler, params, store, constraints)
-        currentNode.addChild(node)
-      }
-
-    // the longest common prefix is smaller than the path length,
-    // but is higher than the prefix
-    } else if (len < path.length) {
-      // remove the prefix
-      path = path.slice(len)
-      // check if there is a child with the label extracted from the new path
-      if (path.charCodeAt(0) === 58) {
-        if (path.charCodeAt(1) === 58) {
-          node = currentNode.staticChildren[':']
-        } else {
-          node = currentNode.parametricChild
-        }
-      } else if (path.charCodeAt(0) === 42) {
-        node = currentNode.wildcardChild
-      } else {
-        node = currentNode.staticChildren[path[0]]
-      }
-
-      // there is a child within the given label, we must go deepen in the tree
-      if (node) {
-        currentNode = node
-        continue
-      }
-
-      for (let i = 0; i < path.length; i++) {
-        if (path.charCodeAt(i) === 58 && path.charCodeAt(i + 1) === 58) {
-          path = path.slice(0, i) + path.slice(i + 1)
-        }
-      }
-
-      // there are not children within the given label, let's create a new one!
-      node = new Node({ method: method, prefix: path, kind: kind, handlers: null, regex: regex, constrainer: this.constrainer })
-      node.addHandler(handler, params, store, constraints)
-      currentNode.addChild(node)
-
-    // the node already exist
-    } else if (handler) {
-      assert(!currentNode.getHandler(constraints), `Method '${method}' already declared for route '${route}' with constraints '${JSON.stringify(constraints)}'`)
-      currentNode.addHandler(handler, params, store, constraints)
-    }
-    return
+    path = path.slice(i)
+    childNode = currentNode.getChildByLabel(path.charAt(0), kind)
   }
+
+  if (path.length > 0) {
+    const node = new Node({ method, prefix: path, kind, handlers: null, regex, constrainer: this.constrainer })
+    currentNode.addChild(node)
+    currentNode = node
+  }
+
+  return currentNode
 }
 
 Router.prototype.reset = function reset () {

--- a/test/issue-17.test.js
+++ b/test/issue-17.test.js
@@ -20,23 +20,37 @@ test('Parametric route, request.url contains dash', t => {
 })
 
 test('Parametric route with fixed suffix', t => {
-  t.plan(2)
+  t.plan(6)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => t.fail('Should not be defaultRoute')
+  })
+
+  findMyWay.on('GET', '/a/:param-static', () => {})
+  findMyWay.on('GET', '/b/:param.static', () => {})
+
+  t.same(findMyWay.find('GET', '/a/param-static', {}).params, { param: 'param' })
+  t.same(findMyWay.find('GET', '/b/param.static', {}).params, { param: 'param' })
+
+  t.same(findMyWay.find('GET', '/a/param-param-static', {}).params, { param: 'param-param' })
+  t.same(findMyWay.find('GET', '/b/param.param.static', {}).params, { param: 'param.param' })
+
+  t.same(findMyWay.find('GET', '/a/param.param-static', {}).params, { param: 'param.param' })
+  t.same(findMyWay.find('GET', '/b/param-param.static', {}).params, { param: 'param-param' })
+})
+
+test('Regex param exceeds max parameter length', t => {
+  t.plan(1)
   const findMyWay = FindMyWay({
     defaultRoute: (req, res) => {
-      t.fail('Should not be defaultRoute')
+      t.ok('route not matched')
     }
   })
 
-  findMyWay.on('GET', '/a/:param-bar', (req, res, params) => {
-    t.equal(params.param, 'foo')
+  findMyWay.on('GET', '/a/:param(^\\w{3})', (req, res, params) => {
+    t.fail('regex match')
   })
 
-  findMyWay.on('GET', '/b/:param.bar', function bloo (req, res, params) {
-    t.equal(params.param, 'foo')
-  })
-
-  findMyWay.lookup({ method: 'GET', url: '/a/foo-bar', headers: {} }, null)
-  findMyWay.lookup({ method: 'GET', url: '/b/foo.bar', headers: {} }, null)
+  findMyWay.lookup({ method: 'GET', url: '/a/fool', headers: {} }, null)
 })
 
 test('Parametric route with regexp and fixed suffix / 1', t => {

--- a/test/issue-238.test.js
+++ b/test/issue-238.test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+
+test('Multi-parametric tricky path', t => {
+  t.plan(6)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => t.fail('Should not be defaultRoute')
+  })
+
+  findMyWay.on('GET', '/:param1-static-:param2', () => {})
+
+  t.same(
+    findMyWay.find('GET', '/param1-static-param2', {}).params,
+    { param1: 'param1', param2: 'param2' }
+  )
+  t.same(
+    findMyWay.find('GET', '/param1.1-param1.2-static-param2.1-param2.2', {}).params,
+    { param1: 'param1.1-param1.2', param2: 'param2.1-param2.2' }
+  )
+  t.same(
+    findMyWay.find('GET', '/param1-1-param1-2-static-param2-1-param2-2', {}).params,
+    { param1: 'param1-1-param1-2', param2: 'param2-1-param2-2' }
+  )
+  t.same(
+    findMyWay.find('GET', '/static-static-static', {}).params,
+    { param1: 'static', param2: 'static' }
+  )
+  t.same(
+    findMyWay.find('GET', '/static-static-static-static', {}).params,
+    { param1: 'static', param2: 'static-static' }
+  )
+  t.same(
+    findMyWay.find('GET', '/static-static1-static-static', {}).params,
+    { param1: 'static-static1', param2: 'static' }
+  )
+})


### PR DESCRIPTION
Fixed #235 #238

The main problem with multi-parametrical nodes is that we can't easily describe the rules of how should it be parsed. Thanks for @mcollina, he said that if I have an unclear case it should work as the [path-to-regexp](https://github.com/pillarjs/path-to-regexp) library does https://github.com/delvedor/find-my-way/issues/238#issuecomment-1021464532. The path-to-regexp converts the hole path to the regexp, so a multi-parametric path is also parsed as a regex. The main idea of this solution is to convert the multi-parametrical part of the path to the regexp. Seems like it's the only way to make it work properly.

**Important point: It doesn't convert the whole path to the regexp (as path-to-regexp does), only the part of the path between two '/' if it contains multiple params or param and static part.**

It replaces parameters with (.*?), regex parameters with themselves, the static part is also inserted into the regex.

Examples:
| Description | Multi-parametrical part of path  | Regexp | 
|---|---|---|
| Param with static part | /:param1-static/ | /^(.*?)-static$/ | 
| Multiple params | /:param1-:param2/ | /^(.\*?)-(.\*?)$/ | 
| Regexp param with param | /:param1(^\\w{3}).param2/ | /^(\w{3})\\.(.\*?)$/  | 

Depends on #243 