### PR TITLE
Define insert method for each node type

### DIFF
--- a/test/issue-104.test.js
+++ b/test/issue-104.test.js
@@ -210,17 +210,14 @@ test('Mixed parametric routes, with last defined route being static', t => {
 test('parametricBrother of Parent Node, with a parametric child', t => {
   t.plan(1)
   const parent = new Node({ prefix: '/a' })
-  const parametricChild = new Node({ prefix: ':id', kind: parent.types.PARAM })
-  parent.addChild(parametricChild)
+  parent.insertParametricNode()
   t.equal(parent.parametricBrother, null)
 })
 
 test('parametricBrother of Parent Node, with a parametric child and a static child', t => {
   t.plan(1)
   const parent = new Node({ prefix: '/a' })
-  const parametricChild = new Node({ prefix: ':id', kind: parent.types.PARAM })
-  const staticChild = new Node({ prefix: '/b', kind: parent.types.STATIC })
-  parent.addChild(parametricChild)
-  parent.addChild(staticChild)
+  parent.insertParametricNode()
+  parent.insertStaticNode('/b')
   t.equal(parent.parametricBrother, null)
 })


### PR DESCRIPTION
Just small refactoring. I split the insert method into three methods for each type of node (static/parametric/wildcard). IMHO it makes the code more self-explaining. 