### PR TITLE
Change ignore trailing slash behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,21 +115,16 @@ Router.prototype.on = function on (method, path, opts, handler, store) {
     return
   }
 
-  const methods = Array.isArray(method) ? method : [method]
-  const paths = [path]
+  const route = path
 
-  if (this.ignoreTrailingSlash && path !== '/' && !path.endsWith('*')) {
-    if (path.endsWith('/')) {
-      paths.push(path.slice(0, -1))
-    } else {
-      paths.push(path + '/')
-    }
+  if (this.ignoreTrailingSlash) {
+    path = trimLastSlash(path)
   }
 
-  for (const path of paths) {
-    for (const method of methods) {
-      this._on(method, path, opts, handler, store)
-    }
+  const methods = Array.isArray(method) ? method : [method]
+  for (const method of methods) {
+    this._on(method, path, opts, handler, store, route)
+    this.routes.push({ method, path, opts, handler, store })
   }
 }
 
@@ -148,8 +143,6 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
   this.constrainer.validateConstraints(constraints)
   // Let the constrainer know if any constraints are being used now
   this.constrainer.noteUsage(constraints)
-
-  this.routes.push({ method, path, opts, handler, store })
 
   // Boot the tree for this method if it doesn't exist yet
   let currentNode = this.trees[method]
@@ -296,17 +289,6 @@ Router.prototype.reset = function reset () {
 }
 
 Router.prototype.off = function off (method, path) {
-  var self = this
-
-  if (Array.isArray(method)) {
-    return method.map(function (method) {
-      return self.off(method, path)
-    })
-  }
-
-  // method validation
-  assert(typeof method === 'string', 'Method should be a string')
-  assert(httpMethods.indexOf(method) !== -1, `Method '${method}' is not an http method.`)
   // path validation
   assert(typeof path === 'string', 'Path should be a string')
   assert(path.length > 0, 'The path could not be empty')
@@ -325,33 +307,30 @@ Router.prototype.off = function off (method, path) {
     return
   }
 
-  // Rebuild tree without the specific route
-  const ignoreTrailingSlash = this.ignoreTrailingSlash
-  var newRoutes = self.routes.filter(function (route) {
-    if (!ignoreTrailingSlash) {
-      return !(method === route.method && path === route.path)
-    }
-    if (path.endsWith('/')) {
-      const routeMatches = path === route.path || path.slice(0, -1) === route.path
-      return !(method === route.method && routeMatches)
-    }
-    const routeMatches = path === route.path || (path + '/') === route.path
-    return !(method === route.method && routeMatches)
-  })
-  if (ignoreTrailingSlash) {
-    newRoutes = newRoutes.filter(function (route, i, ar) {
-      if (route.path.endsWith('/') && i < ar.length - 1) {
-        return route.path.slice(0, -1) !== ar[i + 1].path
-      } else if (route.path.endsWith('/') === false && i < ar.length - 1) {
-        return (route.path + '/') !== ar[i + 1].path
-      }
-      return true
-    })
+  if (this.ignoreTrailingSlash) {
+    path = trimLastSlash(path)
   }
-  self.reset()
-  newRoutes.forEach(function (route) {
-    self.on(route.method, route.path, route.opts, route.handler, route.store)
-  })
+
+  const methods = Array.isArray(method) ? method : [method]
+  for (const method of methods) {
+    this._off(method, path)
+  }
+}
+
+Router.prototype._off = function _off (method, path) {
+  // method validation
+  assert(typeof method === 'string', 'Method should be a string')
+  assert(httpMethods.includes(method), `Method '${method}' is not an http method.`)
+
+  // Rebuild tree without the specific route
+  const newRoutes = this.routes.filter((route) => method !== route.method || path !== route.path)
+  this.reset()
+
+  for (const route of newRoutes) {
+    const { method, path, opts, handler, store } = route
+    this._on(method, path, opts, handler, store)
+    this.routes.push({ method, path, opts, handler, store })
+  }
 }
 
 Router.prototype.lookup = function lookup (req, res, ctx) {
@@ -376,6 +355,10 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
     path = sanitizedUrl.path
   } catch (error) {
     return this._onBadUrl(path)
+  }
+
+  if (this.ignoreTrailingSlash) {
+    path = trimLastSlash(path)
   }
 
   if (this.caseSensitive === false) {
@@ -570,6 +553,13 @@ module.exports = Router
 
 function escapeRegExp (string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function trimLastSlash (path) {
+  if (path.length > 1 && path.charCodeAt(path.length - 1) === 47) {
+    return path.slice(0, -1)
+  }
+  return path
 }
 
 function trimRegExpStartAndEnd (regexString) {

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -205,7 +205,7 @@ test('Method already declared [ignoreTrailingSlash=true]', t => {
       findMyWay.on('GET', '/test/', () => {})
       t.fail('method already declared')
     } catch (e) {
-      t.equal(e.message, 'Method \'GET\' already declared for route \'/test/\' with constraints \'{}\'')
+      t.equal(e.message, 'Method \'GET\' already declared for route \'/test\' with constraints \'{}\'')
     }
   })
 
@@ -226,7 +226,7 @@ test('Method already declared [ignoreTrailingSlash=true]', t => {
       findMyWay.on('GET', '/test/', () => {})
       t.fail('method already declared')
     } catch (e) {
-      t.equal(e.message, 'Method \'GET\' already declared for route \'/test/\' with constraints \'{}\'')
+      t.equal(e.message, 'Method \'GET\' already declared for route \'/test\' with constraints \'{}\'')
     }
   })
 })
@@ -269,7 +269,7 @@ test('Method already declared nested route [ignoreTrailingSlash=true]', t => {
       findMyWay.on('GET', '/test/hello/', () => {})
       t.fail('method already declared')
     } catch (e) {
-      t.equal(e.message, 'Method \'GET\' already declared for route \'/test/hello/\' with constraints \'{}\'')
+      t.equal(e.message, 'Method \'GET\' already declared for route \'/test/hello\' with constraints \'{}\'')
     }
   })
 
@@ -305,7 +305,7 @@ test('Method already declared nested route [ignoreTrailingSlash=true]', t => {
       findMyWay.on('GET', '/test/hello/', () => {})
       t.fail('method already declared')
     } catch (e) {
-      t.equal(e.message, 'Method \'GET\' already declared for route \'/test/hello/\' with constraints \'{}\'')
+      t.equal(e.message, 'Method \'GET\' already declared for route \'/test/hello\' with constraints \'{}\'')
     }
   })
 })

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -148,20 +148,20 @@ test('off removes all routes when ignoreTrailingSlash is true', t => {
   })
 
   findMyWay.on('GET', '/test1/', () => {})
-  t.equal(findMyWay.routes.length, 2)
+  t.equal(findMyWay.routes.length, 1)
 
   findMyWay.on('GET', '/test2', () => {})
-  t.equal(findMyWay.routes.length, 4)
+  t.equal(findMyWay.routes.length, 2)
 
   findMyWay.off('GET', '/test1')
-  t.equal(findMyWay.routes.length, 2)
+  t.equal(findMyWay.routes.length, 1)
   t.equal(
     findMyWay.routes.filter((r) => r.path === '/test2').length,
     1
   )
   t.equal(
     findMyWay.routes.filter((r) => r.path === '/test2/').length,
-    1
+    0
   )
 
   findMyWay.off('GET', '/test2/')


### PR DESCRIPTION
I changed ignoring trailing slash behavior. Instead of creating two duplicated routes (with slash and without), it just removes the trailing slash. Performance is the same, but it's much easier to maintain. It will affect the `routes` field. There will be only one trimmed route instead of two. The `route` field should be used only for debugging, so I don't know if it's a breaking change.