### PR TITLE
Create class for each node type

### DIFF
--- a/custom_node.js
+++ b/custom_node.js
@@ -1,358 +1,117 @@
 'use strict'
 
-const assert = require('assert')
-const deepEqual = require('fast-deep-equal')
+const HandlerStorage = require('./handler_storage')
 
-const types = {
+const NODE_TYPES = {
   STATIC: 0,
-  PARAM: 1,
-  MATCH_ALL: 2,
-  REGEX: 3
+  PARAMETRIC: 1,
+  WILDCARD: 2
 }
 
-function Node (options) {
-  options = options || {}
-  this.prefix = options.prefix || '/'
-  this.label = this.prefix[0]
-  this.method = options.method // not used for logic, just for debugging and pretty printing
-  this.handlers = options.handlers || [] // unoptimized list of handler objects for which the fast matcher function will be compiled
-  this.unconstrainedHandler = options.unconstrainedHandler || null // optimized reference to the handler that will match most of the time
-  this.staticChildren = options.staticChildren || {}
-  this.numberOfChildren = Object.keys(this.staticChildren).length
-  this.kind = options.kind || this.types.STATIC
-  this.regex = options.regex || null
-  this.wildcardChild = null
-  this.parametricChild = null
-  this.wildcardBrother = null
-  this.parametricBrother = null
-  this.constrainer = options.constrainer
-  this.hasConstraints = options.hasConstraints || false
-  this.constrainedHandlerStores = null
+class Node {
+  constructor () {
+    this.handlerStorage = new HandlerStorage()
+  }
 }
 
-Object.defineProperty(Node.prototype, 'types', {
-  value: types
-})
-
-Node.prototype._saveParametricBrother = function () {
-  let parametricBrother = this.parametricBrother
-  if (this.parametricChild !== null) {
-    this.parametricChild.parametricBrother = parametricBrother
-    parametricBrother = this.parametricChild
+class ParentNode extends Node {
+  constructor () {
+    super()
+    this.staticChildren = {}
   }
 
-  // Save the parametric brother inside static children
-  if (parametricBrother) {
-    for (const child of Object.values(this.staticChildren)) {
-      child.parametricBrother = parametricBrother
-      child._saveParametricBrother()
+  findStaticMatchingChild (path, pathIndex) {
+    const staticChild = this.staticChildren[path.charAt(pathIndex)]
+    if (staticChild === undefined) {
+      return null
     }
-  }
-}
 
-Node.prototype._saveWildcardBrother = function () {
-  let wildcardBrother = this.wildcardBrother
-  if (this.wildcardChild !== null) {
-    this.wildcardChild.wildcardBrother = wildcardBrother
-    wildcardBrother = this.wildcardChild
-  }
-
-  // Save the wildcard brother inside static children
-  if (wildcardBrother) {
-    for (const child of Object.values(this.staticChildren)) {
-      child.wildcardBrother = wildcardBrother
-      child._saveWildcardBrother()
-    }
-    if (this.parametricChild !== null) {
-      this.parametricChild.wildcardBrother = wildcardBrother
-    }
-  }
-}
-
-Node.prototype.reset = function (prefix) {
-  this.prefix = prefix
-  this.staticChildren = {}
-  this.handlers = []
-  this.unconstrainedHandler = null
-  this.kind = this.types.STATIC
-  this.numberOfChildren = 0
-  this.regex = null
-  this.wildcardChild = null
-  this.parametricChild = null
-  this.hasConstraints = false
-  this._decompileGetHandlerMatchingConstraints()
-  return this
-}
-
-Node.prototype.split = function (length) {
-  const staticChild = new Node(
-    {
-      prefix: this.prefix.slice(length),
-      staticChildren: this.staticChildren,
-      kind: this.kind,
-      method: this.method,
-      handlers: this.handlers.slice(0),
-      regex: this.regex,
-      constrainer: this.constrainer,
-      hasConstraints: this.hasConstraints,
-      unconstrainedHandler: this.unconstrainedHandler
-    }
-  )
-
-  if (this.wildcardChild !== null) {
-    staticChild.wildcardChild = this.wildcardChild
-  }
-
-  if (this.parametricChild !== null) {
-    staticChild.parametricChild = this.parametricChild
-  }
-
-  this.reset(this.prefix.slice(0, length))
-
-  const label = staticChild.prefix.charAt(0)
-  this.staticChildren[label] = staticChild
-
-  this.numberOfChildren++
-
-  this._saveParametricBrother()
-  this._saveWildcardBrother()
-
-  return staticChild
-}
-
-Node.prototype.insertStaticNode = function (path) {
-  if (path.length === 0) {
-    return this
-  }
-
-  let staticChild = this.staticChildren[path.charAt(0)]
-  if (staticChild) {
-    let i = 0
-    for (; i < staticChild.prefix.length; i++) {
-      if (path.charCodeAt(i) !== staticChild.prefix.charCodeAt(i)) {
-        staticChild.split(i)
-        break
-      }
-    }
-    return staticChild.insertStaticNode(path.slice(i))
-  }
-
-  staticChild = new Node({ method: this.method, prefix: path, kind: types.STATIC, constrainer: this.constrainer })
-
-  const label = path.charAt(0)
-  this.staticChildren[label] = staticChild
-  this.numberOfChildren++
-
-  this._saveParametricBrother()
-  this._saveWildcardBrother()
-
-  return staticChild
-}
-
-Node.prototype.insertParametricNode = function (regex) {
-  if (this.parametricChild) {
-    return this.parametricChild
-  }
-
-  const kind = regex ? types.REGEX : types.PARAM
-  const parametricChild = new Node({ method: this.method, prefix: ':', kind, regex, constrainer: this.constrainer })
-
-  this.parametricChild = parametricChild
-  this.numberOfChildren++
-
-  this._saveParametricBrother()
-  this._saveWildcardBrother()
-
-  return parametricChild
-}
-
-Node.prototype.insertWildcardNode = function () {
-  if (this.wildcardChild) {
-    return this.wildcardChild
-  }
-
-  const wildcardChild = new Node({ method: this.method, prefix: '*', kind: types.MATCH_ALL, constrainer: this.constrainer })
-
-  this.wildcardChild = wildcardChild
-  this.numberOfChildren++
-
-  this._saveWildcardBrother()
-
-  return wildcardChild
-}
-
-Node.prototype.findStaticMatchingChild = function (path, pathIndex) {
-  const child = this.staticChildren[path[pathIndex]]
-  if (child !== undefined) {
-    for (let i = 0; i < child.prefix.length; i++) {
-      if (path.charCodeAt(pathIndex + i) !== child.prefix.charCodeAt(i)) {
+    for (let i = 0; i < staticChild.prefix.length; i++) {
+      if (path.charCodeAt(pathIndex + i) !== staticChild.prefix.charCodeAt(i)) {
         return null
       }
     }
-    return child
-  }
-  return null
-}
-
-Node.prototype.addHandler = function (handler, params, store, constraints) {
-  if (!handler) return
-  assert(!this.getHandler(constraints), `There is already a handler with constraints '${JSON.stringify(constraints)}' and method '${this.method}'`)
-
-  const handlerObject = {
-    handler: handler,
-    params: params,
-    constraints: constraints,
-    store: store || null,
-    paramsLength: params.length
+    return staticChild
   }
 
-  this.handlers.push(handlerObject)
-  // Sort the most constrained handlers to the front of the list of handlers so they are tested first.
-  this.handlers.sort((a, b) => Object.keys(a.constraints).length - Object.keys(b.constraints).length)
+  createStaticChild (path) {
+    if (path.length === 0) {
+      return this
+    }
 
-  if (Object.keys(constraints).length > 0) {
-    this.hasConstraints = true
-  } else {
-    this.unconstrainedHandler = handlerObject
-  }
-
-  if (this.hasConstraints && this.handlers.length > 32) {
-    throw new Error('find-my-way supports a maximum of 32 route handlers per node when there are constraints, limit reached')
-  }
-
-  // Note that the fancy constraint handler matcher needs to be recompiled now that the list of handlers has changed
-  // This lazy compilation means we don't do the compile until the first time the route match is tried, which doesn't waste time re-compiling every time a new handler is added
-  this._decompileGetHandlerMatchingConstraints()
-}
-
-Node.prototype.getHandler = function (constraints) {
-  return this.handlers.filter(handler => deepEqual(constraints, handler.constraints))[0]
-}
-
-// We compile the handler matcher the first time this node is matched. We need to recompile it if new handlers are added, so when a new handler is added, we reset the handler matching function to this base one that will recompile it.
-function compileThenGetHandlerMatchingConstraints (derivedConstraints) {
-  this._compileGetHandlerMatchingConstraints()
-  return this._getHandlerMatchingConstraints(derivedConstraints)
-}
-
-// This is the hot path for node handler finding -- change with care!
-Node.prototype.getMatchingHandler = function (derivedConstraints) {
-  if (derivedConstraints === undefined) {
-    return this.unconstrainedHandler
-  }
-
-  if (this.hasConstraints) {
-    // This node is constrained, use the performant precompiled constraint matcher
-    return this._getHandlerMatchingConstraints(derivedConstraints)
-  }
-
-  // This node doesn't have any handlers that are constrained, so it's handlers probably match. Some requests have constraint values that *must* match however, like version, so check for those before returning it.
-  if (!derivedConstraints.__hasMustMatchValues) {
-    return this.unconstrainedHandler
-  }
-
-  return null
-}
-
-// Slot for the compiled constraint matching function
-Node.prototype._getHandlerMatchingConstraints = compileThenGetHandlerMatchingConstraints
-
-Node.prototype._decompileGetHandlerMatchingConstraints = function () {
-  this._getHandlerMatchingConstraints = compileThenGetHandlerMatchingConstraints
-  return null
-}
-
-// Builds a store object that maps from constraint values to a bitmap of handler indexes which pass the constraint for a value
-// So for a host constraint, this might look like { "fastify.io": 0b0010, "google.ca": 0b0101 }, meaning the 3rd handler is constrainted to fastify.io, and the 2nd and 4th handlers are constrained to google.ca.
-// The store's implementation comes from the strategies provided to the Router.
-Node.prototype._buildConstraintStore = function (constraint) {
-  const store = this.constrainer.newStoreForConstraint(constraint)
-
-  for (let i = 0; i < this.handlers.length; i++) {
-    const handler = this.handlers[i]
-    const mustMatchValue = handler.constraints[constraint]
-    if (typeof mustMatchValue !== 'undefined') {
-      let indexes = store.get(mustMatchValue)
-      if (!indexes) {
-        indexes = 0
+    let staticChild = this.staticChildren[path.charAt(0)]
+    if (staticChild) {
+      let i = 0
+      for (; i < staticChild.prefix.length; i++) {
+        if (path.charCodeAt(i) !== staticChild.prefix.charCodeAt(i)) {
+          staticChild = staticChild.split(this, i)
+          break
+        }
       }
-      indexes |= 1 << i // set the i-th bit for the mask because this handler is constrained by this value https://stackoverflow.com/questions/1436438/how-do-you-set-clear-and-toggle-a-single-bit-in-javascrip
-      store.set(mustMatchValue, indexes)
+      return staticChild.createStaticChild(path.slice(i))
     }
-  }
 
-  return store
+    const label = path.charAt(0)
+    this.staticChildren[label] = new StaticNode(path)
+    return this.staticChildren[label]
+  }
 }
 
-// Builds a bitmask for a given constraint that has a bit for each handler index that is 0 when that handler *is* constrained and 1 when the handler *isnt* constrainted. This is opposite to what might be obvious, but is just for convienience when doing the bitwise operations.
-Node.prototype._constrainedIndexBitmask = function (constraint) {
-  let mask = 0b0
-  for (let i = 0; i < this.handlers.length; i++) {
-    const handler = this.handlers[i]
-    if (handler.constraints && constraint in handler.constraints) {
-      mask |= 1 << i
-    }
+class StaticNode extends ParentNode {
+  constructor (prefix) {
+    super()
+    this.prefix = prefix
+    this.wildcardChild = null
+    this.parametricChild = null
+    this.kind = NODE_TYPES.STATIC
   }
-  return ~mask
+
+  createParametricChild (regex) {
+    if (this.parametricChild) {
+      return this.parametricChild
+    }
+
+    this.parametricChild = new ParametricNode(regex)
+    return this.parametricChild
+  }
+
+  createWildcardChild () {
+    if (this.wildcardChild) {
+      return this.wildcardChild
+    }
+
+    this.wildcardChild = new WildcardNode()
+    return this.wildcardChild
+  }
+
+  split (parentNode, length) {
+    const parentPrefix = this.prefix.slice(0, length)
+    const childPrefix = this.prefix.slice(length)
+
+    this.prefix = childPrefix
+
+    const staticNode = new StaticNode(parentPrefix)
+    staticNode.staticChildren[childPrefix.charAt(0)] = this
+    parentNode.staticChildren[parentPrefix.charAt(0)] = staticNode
+
+    return staticNode
+  }
 }
 
-// Compile a fast function to match the handlers for this node
-// The function implements a general case multi-constraint matching algorithm.
-// The general idea is this: we have a bunch of handlers, each with a potentially different set of constraints, and sometimes none at all. We're given a list of constraint values and we have to use the constraint-value-comparison strategies to see which handlers match the constraint values passed in.
-// We do this by asking each constraint store which handler indexes match the given constraint value for each store. Trickily, the handlers that a store says match are the handlers constrained by that store, but handlers that aren't constrained at all by that store could still match just fine. So, each constraint store can only describe matches for it, and it won't have any bearing on the handlers it doesn't care about. For this reason, we have to ask each stores which handlers match and track which have been matched (or not cared about) by all of them.
-// We use bitmaps to represent these lists of matches so we can use bitwise operations to implement this efficiently. Bitmaps are cheap to allocate, let us implement this masking behaviour in one CPU instruction, and are quite compact in memory. We start with a bitmap set to all 1s representing every handler that is a match candidate, and then for each constraint, see which handlers match using the store, and then mask the result by the mask of handlers that that store applies to, and bitwise AND with the candidate list. Phew.
-// We consider all this compiling function complexity to be worth it, because the naive implementation that just loops over the handlers asking which stores match is quite a bit slower.
-Node.prototype._compileGetHandlerMatchingConstraints = function () {
-  this.constrainedHandlerStores = {}
-  let constraints = new Set()
-  for (const handler of this.handlers) {
-    for (const key of Object.keys(handler.constraints)) {
-      constraints.add(key)
-    }
+class ParametricNode extends ParentNode {
+  constructor (regex) {
+    super()
+    this.regex = regex || null
+    this.isRegex = !!regex
+    this.kind = NODE_TYPES.PARAMETRIC
   }
-  constraints = Array.from(constraints)
-  const lines = []
-
-  // always check the version constraint first as it is the most selective
-  constraints.sort((a, b) => a === 'version' ? 1 : 0)
-
-  for (const constraint of constraints) {
-    this.constrainedHandlerStores[constraint] = this._buildConstraintStore(constraint)
-  }
-
-  lines.push(`
-  let candidates = 0b${'1'.repeat(this.handlers.length)}
-  let mask, matches
-  `)
-  for (const constraint of constraints) {
-    // Setup the mask for indexes this constraint applies to. The mask bits are set to 1 for each position if the constraint applies.
-    lines.push(`
-    mask = ${this._constrainedIndexBitmask(constraint)}
-    value = derivedConstraints.${constraint}
-    `)
-
-    // If there's no constraint value, none of the handlers constrained by this constraint can match. Remove them from the candidates.
-    // If there is a constraint value, get the matching indexes bitmap from the store, and mask it down to only the indexes this constraint applies to, and then bitwise and with the candidates list to leave only matching candidates left.
-    lines.push(`
-    if (typeof value === "undefined") {
-      candidates &= mask
-    } else {
-      matches = this.constrainedHandlerStores.${constraint}.get(value) || 0
-      candidates &= (matches | mask)
-    }
-    if (candidates === 0) return null;
-    `)
-  }
-  // Return the first handler who's bit is set in the candidates https://stackoverflow.com/questions/18134985/how-to-find-index-of-first-set-bit
-  lines.push(`
-  const handler = this.handlers[Math.floor(Math.log2(candidates))]
-  if (handler && derivedConstraints.__hasMustMatchValues && handler === this.unconstrainedHandler) {
-    return null;
-  }
-  return handler;
-  `)
-
-  this._getHandlerMatchingConstraints = new Function('derivedConstraints', lines.join('\n')) // eslint-disable-line
 }
 
-module.exports = Node
+class WildcardNode extends Node {
+  constructor () {
+    super()
+    this.kind = NODE_TYPES.WILDCARD
+  }
+}
+
+module.exports = { StaticNode, ParametricNode, WildcardNode, NODE_TYPES }

--- a/handler_storage.js
+++ b/handler_storage.js
@@ -1,0 +1,167 @@
+'use strict'
+
+const assert = require('assert')
+const deepEqual = require('fast-deep-equal')
+
+class HandlerStorage {
+  constructor () {
+    this.constrainer = HandlerStorage.prototype.constrainer
+
+    this.handlers = [] // unoptimized list of handler objects for which the fast matcher function will be compiled
+    this.hasConstraints = false
+    this.compiledHandler = null
+    this.unconstrainedHandler = null // optimized reference to the handler that will match most of the time
+    this.constrainedHandlerStores = null
+  }
+
+  getHandler (constraints) {
+    return this.handlers.filter(handler => deepEqual(constraints, handler.constraints))[0]
+  }
+
+  // This is the hot path for node handler finding -- change with care!
+  getMatchingHandler (derivedConstraints) {
+    if (derivedConstraints === undefined) {
+      return this.unconstrainedHandler
+    }
+
+    if (this.hasConstraints) {
+      // This node is constrained, use the performant precompiled constraint matcher
+      return this._getHandlerMatchingConstraints(derivedConstraints)
+    }
+
+    // This node doesn't have any handlers that are constrained, so it's handlers probably match. Some requests have constraint values that *must* match however, like version, so check for those before returning it.
+    if (!derivedConstraints.__hasMustMatchValues) {
+      return this.unconstrainedHandler
+    }
+
+    return null
+  }
+
+  addHandler (handler, params, store, constraints) {
+    if (!handler) return
+    assert(!this.getHandler(constraints), `There is already a handler with constraints '${JSON.stringify(constraints)}' and method '${this.method}'`)
+
+    const handlerObject = { handler, params, constraints, store: store || null, paramsLength: params.length }
+
+    this.handlers.push(handlerObject)
+    // Sort the most constrained handlers to the front of the list of handlers so they are tested first.
+    this.handlers.sort((a, b) => Object.keys(a.constraints).length - Object.keys(b.constraints).length)
+
+    if (Object.keys(constraints).length > 0) {
+      this.hasConstraints = true
+    } else {
+      this.unconstrainedHandler = handlerObject
+    }
+
+    if (this.hasConstraints && this.handlers.length > 32) {
+      throw new Error('find-my-way supports a maximum of 32 route handlers per node when there are constraints, limit reached')
+    }
+
+    // Note that the fancy constraint handler matcher needs to be recompiled now that the list of handlers has changed
+    // This lazy compilation means we don't do the compile until the first time the route match is tried, which doesn't waste time re-compiling every time a new handler is added
+    this.compiledHandler = null
+  }
+
+  // Slot for the compiled constraint matching function
+  _getHandlerMatchingConstraints (derivedConstraints) {
+    if (this.compiledHandler === null) {
+      this.compiledHandler = this._compileGetHandlerMatchingConstraints()
+    }
+    return this.compiledHandler(derivedConstraints)
+  }
+
+  // Builds a store object that maps from constraint values to a bitmap of handler indexes which pass the constraint for a value
+  // So for a host constraint, this might look like { "fastify.io": 0b0010, "google.ca": 0b0101 }, meaning the 3rd handler is constrainted to fastify.io, and the 2nd and 4th handlers are constrained to google.ca.
+  // The store's implementation comes from the strategies provided to the Router.
+  _buildConstraintStore (constraint) {
+    const store = this.constrainer.newStoreForConstraint(constraint)
+
+    for (let i = 0; i < this.handlers.length; i++) {
+      const handler = this.handlers[i]
+      const mustMatchValue = handler.constraints[constraint]
+      if (typeof mustMatchValue !== 'undefined') {
+        let indexes = store.get(mustMatchValue)
+        if (!indexes) {
+          indexes = 0
+        }
+        indexes |= 1 << i // set the i-th bit for the mask because this handler is constrained by this value https://stackoverflow.com/questions/1436438/how-do-you-set-clear-and-toggle-a-single-bit-in-javascrip
+        store.set(mustMatchValue, indexes)
+      }
+    }
+
+    return store
+  }
+
+  // Builds a bitmask for a given constraint that has a bit for each handler index that is 0 when that handler *is* constrained and 1 when the handler *isnt* constrainted. This is opposite to what might be obvious, but is just for convienience when doing the bitwise operations.
+  _constrainedIndexBitmask (constraint) {
+    let mask = 0b0
+    for (let i = 0; i < this.handlers.length; i++) {
+      const handler = this.handlers[i]
+      if (handler.constraints && constraint in handler.constraints) {
+        mask |= 1 << i
+      }
+    }
+    return ~mask
+  }
+
+  // Compile a fast function to match the handlers for this node
+  // The function implements a general case multi-constraint matching algorithm.
+  // The general idea is this: we have a bunch of handlers, each with a potentially different set of constraints, and sometimes none at all. We're given a list of constraint values and we have to use the constraint-value-comparison strategies to see which handlers match the constraint values passed in.
+  // We do this by asking each constraint store which handler indexes match the given constraint value for each store. Trickily, the handlers that a store says match are the handlers constrained by that store, but handlers that aren't constrained at all by that store could still match just fine. So, each constraint store can only describe matches for it, and it won't have any bearing on the handlers it doesn't care about. For this reason, we have to ask each stores which handlers match and track which have been matched (or not cared about) by all of them.
+  // We use bitmaps to represent these lists of matches so we can use bitwise operations to implement this efficiently. Bitmaps are cheap to allocate, let us implement this masking behaviour in one CPU instruction, and are quite compact in memory. We start with a bitmap set to all 1s representing every handler that is a match candidate, and then for each constraint, see which handlers match using the store, and then mask the result by the mask of handlers that that store applies to, and bitwise AND with the candidate list. Phew.
+  // We consider all this compiling function complexity to be worth it, because the naive implementation that just loops over the handlers asking which stores match is quite a bit slower.
+  _compileGetHandlerMatchingConstraints () {
+    this.constrainedHandlerStores = {}
+    let constraints = new Set()
+    for (const handler of this.handlers) {
+      for (const key of Object.keys(handler.constraints)) {
+        constraints.add(key)
+      }
+    }
+    constraints = Array.from(constraints)
+    const lines = []
+
+    // always check the version constraint first as it is the most selective
+    constraints.sort((a, b) => a === 'version' ? 1 : 0)
+
+    for (const constraint of constraints) {
+      this.constrainedHandlerStores[constraint] = this._buildConstraintStore(constraint)
+    }
+
+    lines.push(`
+    let candidates = 0b${'1'.repeat(this.handlers.length)}
+    let mask, matches
+    `)
+    for (const constraint of constraints) {
+      // Setup the mask for indexes this constraint applies to. The mask bits are set to 1 for each position if the constraint applies.
+      lines.push(`
+      mask = ${this._constrainedIndexBitmask(constraint)}
+      value = derivedConstraints.${constraint}
+      `)
+
+      // If there's no constraint value, none of the handlers constrained by this constraint can match. Remove them from the candidates.
+      // If there is a constraint value, get the matching indexes bitmap from the store, and mask it down to only the indexes this constraint applies to, and then bitwise and with the candidates list to leave only matching candidates left.
+      lines.push(`
+      if (typeof value === "undefined") {
+        candidates &= mask
+      } else {
+        matches = this.constrainedHandlerStores.${constraint}.get(value) || 0
+        candidates &= (matches | mask)
+      }
+      if (candidates === 0) return null;
+      `)
+    }
+    // Return the first handler who's bit is set in the candidates https://stackoverflow.com/questions/18134985/how-to-find-index-of-first-set-bit
+    lines.push(`
+    const handler = this.handlers[Math.floor(Math.log2(candidates))]
+    if (handler && derivedConstraints.__hasMustMatchValues && handler === this.unconstrainedHandler) {
+      return null;
+    }
+    return handler;
+    `)
+
+    return new Function('derivedConstraints', lines.join('\n')) // eslint-disable-line
+  }
+}
+
+module.exports = HandlerStorage

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -189,9 +189,9 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts) {
   let paramName = ''
   const printHandlers = []
 
-  for (const node of flattenedNode.nodes) {
-    for (const handler of node.handlers) {
-      printHandlers.push({ method: node.method, ...handler })
+  for (const { node, method } of flattenedNode.nodes) {
+    for (const handler of node.handlerStorage.handlers) {
+      printHandlers.push({ method, ...handler })
     }
   }
 
@@ -248,39 +248,53 @@ function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts) {
   return tree
 }
 
-function flattenNode (flattened, node) {
-  if (node.handlers.length > 0) {
-    flattened.nodes.push(node)
+function flattenNode (flattened, node, method) {
+  if (node.handlerStorage.handlers.length > 0) {
+    flattened.nodes.push({ method, node })
   }
 
-  const nodeChildren = Object.values(node.staticChildren)
-
   if (node.parametricChild) {
-    nodeChildren.unshift(node.parametricChild)
+    if (!flattened.children[':']) {
+      flattened.children[':'] = {
+        prefix: ':',
+        nodes: [],
+        children: {}
+      }
+    }
+    flattenNode(flattened.children[':'], node.parametricChild, method)
   }
 
   if (node.wildcardChild) {
-    nodeChildren.unshift(node.wildcardChild)
-  }
-
-  for (const child of nodeChildren) {
-    // split on the slash separator but use a regex to lookahead and not actually match it, preserving it in the returned string segments
-    const childPrefixSegments = child.prefix.split(pathRegExp)
-    let cursor = flattened
-    let parent
-    for (const segment of childPrefixSegments) {
-      parent = cursor
-      cursor = cursor.children[segment]
-      if (!cursor) {
-        cursor = {
-          prefix: segment,
-          nodes: [],
-          children: {}
-        }
-        parent.children[segment] = cursor
+    if (!flattened.children['*']) {
+      flattened.children['*'] = {
+        prefix: '*',
+        nodes: [],
+        children: {}
       }
     }
-    flattenNode(cursor, child)
+    flattenNode(flattened.children['*'], node.wildcardChild, method)
+  }
+
+  if (node.staticChildren) {
+    for (const child of Object.values(node.staticChildren)) {
+      // split on the slash separator but use a regex to lookahead and not actually match it, preserving it in the returned string segments
+      const childPrefixSegments = child.prefix.split(pathRegExp)
+      let cursor = flattened
+      let parent
+      for (const segment of childPrefixSegments) {
+        parent = cursor
+        cursor = cursor.children[segment]
+        if (!cursor) {
+          cursor = {
+            prefix: segment,
+            nodes: [],
+            children: {}
+          }
+          parent.children[segment] = cursor
+        }
+      }
+      flattenNode(cursor, child, method)
+    }
   }
 }
 

--- a/test/issue-104.test.js
+++ b/test/issue-104.test.js
@@ -3,7 +3,6 @@
 const t = require('tap')
 const test = t.test
 const FindMyWay = require('../')
-const Node = require('../custom_node')
 
 test('Nested static parametric route, url with parameter common prefix > 1', t => {
   t.plan(1)
@@ -205,19 +204,4 @@ test('Mixed parametric routes, with last defined route being static', t => {
   t.same(findMyWay.find('GET', '/test/hello/world/test').params, { c: 'world' })
   t.same(findMyWay.find('GET', '/test/hello/world/te').params, { c: 'world', k: 'te' })
   t.same(findMyWay.find('GET', '/test/hello/world/testy').params, { c: 'world', k: 'testy' })
-})
-
-test('parametricBrother of Parent Node, with a parametric child', t => {
-  t.plan(1)
-  const parent = new Node({ prefix: '/a' })
-  parent.insertParametricNode()
-  t.equal(parent.parametricBrother, null)
-})
-
-test('parametricBrother of Parent Node, with a parametric child and a static child', t => {
-  t.plan(1)
-  const parent = new Node({ prefix: '/a' })
-  parent.insertParametricNode()
-  parent.insertStaticNode('/b')
-  t.equal(parent.parametricBrother, null)
 })


### PR DESCRIPTION
I refactored the Node entity:
- Divided the Node into the three different classes: StaticNode, ParametricNode, WildcardNode; each of these classes has a different set of properties and methods
- Moved everything related to handlers and matching constraints to the separate entity: HandlerStorage