### PR TITLE
Fix matching order

### DIFF
--- a/test/matching-order.test.js
+++ b/test/matching-order.test.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('..')
+
+test('Matching order', t => {
+  t.plan(3)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/foo/bar/static', { constraints: { host: 'test' } }, () => {})
+  findMyWay.on('GET', '/foo/bar/*', () => {})
+  findMyWay.on('GET', '/foo/:param/static', () => {})
+
+  t.same(findMyWay.find('GET', '/foo/bar/static', { host: 'test' }).params, {})
+  t.same(findMyWay.find('GET', '/foo/bar/static').params, { '*': 'static' })
+  t.same(findMyWay.find('GET', '/foo/value/static').params, { param: 'value' })
+})


### PR DESCRIPTION
As far as I understand from the documentation, the route with the longest match of the static part has a higher priority.
https://github.com/delvedor/find-my-way#match-order

So for the `/foo/bar/static` path, `/foo/bar/*` route has higher priority than `/foo/:param/static`. If it's correct, it wasn't working for some cases.