### PR TITLE
Add Node.js v18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [12.x, 14.x, 16.x, 17.x, 18.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:


### PR DESCRIPTION
Should we just add v18, or replace v17?