### PR TITLE
Normalize benchmark paths

### DIFF
--- a/bench-thread.js
+++ b/bench-thread.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { workerData, parentPort } = require('worker_threads')
+const { workerData: benchmark, parentPort } = require('worker_threads')
 
 const Benchmark = require('benchmark')
 // The default number of samples for Benchmark seems to be low enough that it
@@ -14,18 +14,9 @@ Benchmark.options.minSamples = 500
 const suite = Benchmark.Suite()
 
 const FindMyWay = require('./')
-
 const findMyWay = new FindMyWay()
 
-const testingMethods = {
-  lookup: findMyWay.lookup,
-  find: findMyWay.find
-}
-
-const { name, setupURLs, testingMethodName, args } = workerData
-const testingMethod = testingMethods[testingMethodName]
-
-for (const { method, url, opts } of setupURLs) {
+for (const { method, url, opts } of benchmark.setupURLs) {
   if (opts !== undefined) {
     findMyWay.on(method, url, opts, () => true)
   } else {
@@ -34,8 +25,8 @@ for (const { method, url, opts } of setupURLs) {
 }
 
 suite
-  .add(name, () => {
-    testingMethod.call(findMyWay, ...args)
+  .add(benchmark.name, () => {
+    findMyWay.lookup(...benchmark.arguments)
   })
   .on('cycle', (event) => {
     parentPort.postMessage(String(event.target))


### PR DESCRIPTION
Benchmark refactoring:
- Updated benchmarks paths. All benchmark test routes have different paths and it takes significant time to iterate a path char by char. So some test cases can look really slow, not for the reason we are trying to test, but just because they have lost static prefix. I made paths the same where it makes sense, so it's easier to compare benchmarks between themselves.
- Removed find method benchmarks. Almost all find method benchmarks are duplicating lookup benchmarks. They have some sense because lookup adds some overhead by deriving constraints and calling a handler. But since we use an empty handler and almost empty constraint this overhead is really small and constant. From my experience find method benchmarks don't give any new information, after running lookup benchmarks.
- Added some new benchmarks.
- Aligned test names.

<img width="846" alt="Снимок экрана 2022-04-29 в 20 09 13" src="https://user-images.githubusercontent.com/31734731/165991228-dbee2853-f92b-475d-9c0e-a550610b5af6.png">
