### PR TITLE
Add querrystring parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ const router = require('find-my-way')({
 })
 ```
 
+The default query string parser that find-my-way uses is the Node.js's core querystring module. You can change this default setting by passing the option querystringParser and use a custom one, such as [qs](https://www.npmjs.com/package/qs).
+
+```js
+const qs = require('qs')
+const router = require('find-my-way')({
+  querystringParser: str => qs.parse(str)
+})
+
+router.on('GET', '/', (req, res, params, store, searchParams) => {
+  assert.equal(searchParams, { foo: 'bar', baz: 'faz' })
+})
+
+router.lookup({ method: 'GET', url: '/?foo=bar&baz=faz' }, null)
+```
+
 You can assign a `buildPrettyMeta` function to sanitize a route's `store` object to use with the `prettyPrint` functions. This function should accept a single object and return an object.
 
 ```js
@@ -227,7 +242,7 @@ The signature of the functions and objects must match the one from the example a
 #### on(method, path, [opts], handler, [store])
 Register a new route.
 ```js
-router.on('GET', '/example', (req, res, params) => {
+router.on('GET', '/example', (req, res, params, store, searchParams) => {
   // your code
 })
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,8 @@ declare namespace Router {
     req: Req<V>,
     res: Res<V>,
     params: { [k: string]: string | undefined },
-    store: any
+    store: any,
+    searchParams: { [k: string]: string }
   ) => any;
 
   interface ConstraintStrategy<V extends HTTPVersion, T = string> {
@@ -110,6 +111,7 @@ declare namespace Router {
     handler: Handler<V>;
     params: { [k: string]: string | undefined };
     store: any;
+    searchParams: { [k: string]: string };
   }
 
   interface Instance<V extends HTTPVersion> {

--- a/lib/url-sanitizer.js
+++ b/lib/url-sanitizer.js
@@ -36,6 +36,7 @@ function decodeComponentChar (highCharCode, lowCharCode) {
 
 function safeDecodeURI (path) {
   let shouldDecode = false
+  let querystring = ''
 
   for (let i = 1; i < path.length; i++) {
     const charCode = path.charCodeAt(i)
@@ -59,14 +60,16 @@ function safeDecodeURI (path) {
     // string with a `;` character (code 59), e.g. `/foo;jsessionid=123456`.
     // Thus, we need to split on `;` as well as `?` and `#`.
     } else if (charCode === 63 || charCode === 59 || charCode === 35) {
+      querystring = path.slice(i + 1)
       path = path.slice(0, i)
       break
     }
   }
-  return shouldDecode ? decodeURI(path) : path
+  const decodedPath = shouldDecode ? decodeURI(path) : path
+  return { path: decodedPath, querystring }
 }
 
-function safeDecodeURIComponent (uriComponent, startIndex = 0) {
+function safeDecodeURIComponent (uriComponent, startIndex) {
   let decoded = ''
   let lastIndex = startIndex
 

--- a/test/custom-querystring-parser.test.js
+++ b/test/custom-querystring-parser.test.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const querystring = require('querystring')
+const FindMyWay = require('../')
+
+test('Custom querystring parser', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay({
+    querystringParser: function (str) {
+      t.equal(str, 'foo=bar&baz=faz')
+      return querystring.parse(str)
+    }
+  })
+  findMyWay.on('GET', '/', () => {})
+
+  t.same(findMyWay.find('GET', '/?foo=bar&baz=faz').searchParams, { foo: 'bar', baz: 'faz' })
+})
+
+test('Custom querystring parser should be called also if there is nothing to parse', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay({
+    querystringParser: function (str) {
+      t.equal(str, '')
+      return querystring.parse(str)
+    }
+  })
+  findMyWay.on('GET', '/', () => {})
+
+  t.same(findMyWay.find('GET', '/').searchParams, {})
+})
+
+test('Querystring without value', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay({
+    querystringParser: function (str) {
+      t.equal(str, 'foo')
+      return querystring.parse(str)
+    }
+  })
+  findMyWay.on('GET', '/', () => {})
+  t.same(findMyWay.find('GET', '/?foo').searchParams, { foo: '' })
+})

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -435,7 +435,7 @@ test('find should return the route', t => {
 
   t.same(
     findMyWay.find('GET', '/test'),
-    { handler: fn, params: {}, store: null }
+    { handler: fn, params: {}, store: null, searchParams: {} }
   )
 })
 
@@ -448,7 +448,7 @@ test('find should return the route with params', t => {
 
   t.same(
     findMyWay.find('GET', '/test/hello'),
-    { handler: fn, params: { id: 'hello' }, store: null }
+    { handler: fn, params: { id: 'hello' }, store: null, searchParams: {} }
   )
 })
 
@@ -471,7 +471,7 @@ test('should decode the uri - parametric', t => {
 
   t.same(
     findMyWay.find('GET', '/test/he%2Fllo'),
-    { handler: fn, params: { id: 'he/llo' }, store: null }
+    { handler: fn, params: { id: 'he/llo' }, store: null, searchParams: {} }
   )
 })
 
@@ -484,7 +484,7 @@ test('should decode the uri - wildcard', t => {
 
   t.same(
     findMyWay.find('GET', '/test/he%2Fllo'),
-    { handler: fn, params: { '*': 'he/llo' }, store: null }
+    { handler: fn, params: { '*': 'he/llo' }, store: null, searchParams: {} }
   )
 })
 

--- a/test/querystring.test.js
+++ b/test/querystring.test.js
@@ -5,10 +5,11 @@ const test = t.test
 const FindMyWay = require('../')
 
 test('should sanitize the url - query', t => {
-  t.plan(1)
+  t.plan(2)
   const findMyWay = FindMyWay()
 
-  findMyWay.on('GET', '/test', (req, res, params) => {
+  findMyWay.on('GET', '/test', (req, res, params, store, query) => {
+    t.same(query, { hello: 'world' })
     t.ok('inside the handler')
   })
 
@@ -16,10 +17,11 @@ test('should sanitize the url - query', t => {
 })
 
 test('should sanitize the url - hash', t => {
-  t.plan(1)
+  t.plan(2)
   const findMyWay = FindMyWay()
 
-  findMyWay.on('GET', '/test', (req, res, params) => {
+  findMyWay.on('GET', '/test', (req, res, params, store, query) => {
+    t.same(query, { hello: '' })
     t.ok('inside the handler')
   })
 
@@ -27,10 +29,11 @@ test('should sanitize the url - hash', t => {
 })
 
 test('handles path and query separated by ;', t => {
-  t.plan(1)
+  t.plan(2)
   const findMyWay = FindMyWay()
 
-  findMyWay.on('GET', '/test', (req, res, params) => {
+  findMyWay.on('GET', '/test', (req, res, params, store, query) => {
+    t.same(query, { jsessionid: '123456' })
     t.ok('inside the handler')
   })
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -25,7 +25,8 @@ test('find a store object', t => {
   t.same(findMyWay.find('GET', '/test'), {
     handler: fn,
     params: {},
-    store: { hello: 'world' }
+    store: { hello: 'world' },
+    searchParams: {}
   })
 })
 


### PR DESCRIPTION
We are already searching the querystring in the path and are spending some time on it. I want to pass the querystring to the handler instead of parsing it again in the handler. The querystring would be passed to the handler as a new argument.

\+ find-my-way handle ';' as a querystring start symbol and fastify doesn't.

The changes to the fastify:
https://github.com/ivan-tymoshenko/fastify/commit/00087f04117844ec7be7b23a9e2d0d8fe4b12e2c

Benchmarks:
In the main branch, I added a handler that parses querystring in the same way as fastify does 
(https://github.com/fastify/fastify/blob/0a4649f504bd466ce7dd37b510832746b213b2d4/lib/route.js#L377) and compared it with parsing a querystring natively in the find-my-way.

Handler in the main branch:

```js
  findMyWay.on(method, url, (req) => {
    const queryPrefix = req.url.indexOf('?')
    const query = querystring.parse(queryPrefix > -1 ? req.url.slice(queryPrefix + 1) : '')
    return query
  })
```

<img width="744" alt="Снимок экрана 2022-05-15 в 18 23 22" src="https://user-images.githubusercontent.com/31734731/168480888-a75a9ad8-a3f0-47a8-be73-8f70f7242a43.png">