### PR TITLE
fix: remove max param length on wildcard

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,10 +441,6 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
         param = safeDecodeURIComponent(param)
       }
 
-      if (param.length > maxParamLength) {
-        return null
-      }
-
       params.push(param)
       pathIndex = pathLen
       continue

--- a/test/fastify-issue-3957.test.js
+++ b/test/fastify-issue-3957.test.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const FindMyWay = require('../')
+
+test('wildcard should not limit by maxParamLength', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay({
+    defaultRoute: (req, res) => {
+      t.fail('we should not be here, the url is: ' + req.url)
+    }
+  })
+
+  findMyWay.on('GET', '*', (req, res, params) => {
+    t.same(params['*'], '/portfolios/b5859fb9-6c76-4db8-b3d1-337c5be3fd8b/instruments/2a694406-b43f-439d-aa11-0c814805c930/positions')
+  })
+
+  findMyWay.lookup(
+    { method: 'GET', url: '/portfolios/b5859fb9-6c76-4db8-b3d1-337c5be3fd8b/instruments/2a694406-b43f-439d-aa11-0c814805c930/positions', headers: {} },
+    null
+  )
+})


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify/issues/3957

It is very common that people expect `wildcard` route as a fallback / catch-all route in their application.
Since, it will match all the thing include each path segment. 
Restricting the length of `wildcard` like the other `param / regexp` seems unnecessary and out of user expectation.

I think this behavior is bring from https://github.com/delvedor/find-my-way/pull/237