### PR TITLE
chore!: drop support for node 12 and 17

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "speed"
   ],
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
   "license": "MIT",


### PR DESCRIPTION
BREAKING CHANGE: Drops support for EOL node 12 and 17.

Made changes in the same places as v5.0.0 when that dropped support for node 10: https://github.com/delvedor/find-my-way/commit/b1cf7cbc90199f8d532ec93cbbd317f0bc3001bd