### PR TITLE
fix matcher function in off method and fix regex tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,29 +409,69 @@ Once a url has been matched, `find-my-way` will figure out which handler registe
 The router is able to route all HTTP methods defined by [`http` core module](https://nodejs.org/api/http.html#http_http_methods).
 
 <a name="off"></a>
-#### off(method, path)
-Deregister a route.
+#### off(methods[], path, [constraints])
+
+Used to deregister routes.
+
+<a name="off-without-constraints"></a>
+##### off(methods, path)
+
+If no constraint argument is passed, all routes with identical path and method are deregistered, regardless of whether 
+a route has constraints or not.
+
 ```js
+router.on('GET', '/example', { constraints: { host: 'fastify.io' } })
+router.on('GET', '/example', { constraints: { version: '1.x' } })
+router.on('GET', '/example')
+
+// Deregisters all 3 routes registered above
 router.off('GET', '/example')
-// => { handler: Function, params: Object, store: Object}
-// => null
+```
+
+##### off(methods, path, constraints)
+
+If a constraint object is specified, only those routes are deleted that have the same constraints as well as the 
+identical path and method. If an empty object is passed, only unconstrained routes will be deleted.
+```js
+router.on('GET', '/example', { constraints: { host: 'fastify.io' } })
+router.on('GET', '/example', { constraints: { version: '1.x' } })
+router.on('GET', '/example')
+
+// Deregisters only the third route without constraints
+router.off('GET', '/example', {})
+
+// Deregisters only the first route
+router.off('GET', '/example', { host: 'fastify.io' })
 ```
 
 ##### off(methods[], path)
-Deregister a route for each method specified in the `methods` array.
-It comes handy when you need to deregister multiple routes with the same path but different methods.
+
+Deregister a route for each method specified in the methods array. It comes handy when you need to deregister multiple 
+routes with the same path but different methods. As explained above, the constraints will be ignored here.
+
 ```js
-router.off(['GET', 'POST'], '/example')
-// => [{ handler: Function, params: Object, store: Object}]
-// => null
+router.on('GET', '/example', { constraints: { host: 'fastify.io' } })
+router.on('POST', '/example', { constraints: { version: '1.x' } })
+router.on('PUT', '/example')
+
+// Deregisters all 3 routes registered above
+router.off(['POST', 'GET', 'PUT'], '/example')
 ```
 
-##### off(methods, path, [constraints])
-Deregister a route for each `constraints` key is matched, containing keys like the `host` for the request, the `version` for the route to be matched, or other custom constraint values. See the [constraints section](https://github.com/delvedor/find-my-way#constraints) to know more.
+##### off(methods[], path, constraints)
+
 ```js
-router.off('GET', '/example', { host: 'fastify.io' })
-// => [{ handler: Function, params: Object, store: Object}]
-// => null
+router.on('GET', '/example', { constraints: { host: 'fastify.io' } }) // first route
+router.on('POST', '/example', { constraints: { host: 'fastify.io' } }) // second route
+router.on('POST', '/example', { constraints: { host: 'google.de' } }) // third route
+router.on('GET', '/example') // fourth route 
+router.on('POST', '/example') // fifth route 
+
+// Deregisters only first and second route
+router.off(['POST', 'GET'], '/example', { host: 'fastify.io' })
+
+// Deregisters only fourth and fifth route
+router.off(['POST', 'GET'], '/example', {})
 ```
 
 <a name="reset"></a>

--- a/index.js
+++ b/index.js
@@ -351,7 +351,10 @@ Router.prototype._off = function _off (method, path, opts) {
   assert(httpMethods.includes(method), `Method '${method}' is not an http method.`)
 
   function matcher (currentConstraints) {
-    if (!opts || !currentConstraints) return true
+    // no constraints given so we delete all routes no matter if with constraints or not
+    if (!opts) return true
+    // the route to be deleted has constraints but the current route does not, so it is not deleted
+    if (!currentConstraints) return false
 
     return deepEqual(opts, currentConstraints)
   }

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -775,7 +775,7 @@ test('off removes all routes without checking constraints if no constraints are 
 })
 
 test('off removes only constrainted routes if constraints are specified', t => {
-  t.plan(1)
+  t.plan(2)
 
   const findMyWay = FindMyWay()
 
@@ -785,6 +785,7 @@ test('off removes only constrainted routes if constraints are specified', t => {
   findMyWay.off('GET', '/test', { host: 'example.com' })
 
   t.equal(findMyWay.routes.length, 1)
+  t.notOk(findMyWay.routes[0].opts.constraints)
 })
 
 test('off removes no routes if provided constraints does not match any registered route', t => {
@@ -799,4 +800,31 @@ test('off removes no routes if provided constraints does not match any registere
   findMyWay.off('GET', '/test', { version: '1.x' })
 
   t.equal(findMyWay.routes.length, 3)
+})
+
+test('off validates that constraints is an object or undefined', t => {
+  t.plan(6)
+
+  const findMyWay = FindMyWay()
+
+  t.throws(() => findMyWay.off('GET', '/', 2))
+  t.throws(() => findMyWay.off('GET', '/', 'should throw'))
+  t.throws(() => findMyWay.off('GET', '/', []))
+  t.doesNotThrow(() => findMyWay.off('GET', '/', undefined))
+  t.doesNotThrow(() => findMyWay.off('GET', '/', {}))
+  t.doesNotThrow(() => findMyWay.off('GET', '/'))
+})
+
+test('off removes only unconstrainted route if an empty object is given as constraints', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.get('/', {}, () => {})
+  findMyWay.get('/', { constraints: { host: 'fastify.io' } }, () => {})
+
+  findMyWay.off('GET', '/', {})
+
+  t.equal(findMyWay.routes.length, 1)
+  t.equal(findMyWay.routes[0].opts.constraints.host, 'fastify.io')
 })

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -760,3 +760,43 @@ test('register all known HTTP methods', t => {
   t.ok(findMyWay.find('M-SEARCH', '/test'))
   t.equal(findMyWay.find('M-SEARCH', '/test').handler, handlers['M-SEARCH'])
 })
+
+test('off removes all routes without checking constraints if no constraints are specified', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/test', {}, (req, res) => {})
+  findMyWay.on('GET', '/test', { constraints: { host: 'example.com' } }, (req, res) => {})
+
+  findMyWay.off('GET', '/test')
+
+  t.equal(findMyWay.routes.length, 0)
+})
+
+test('off removes only constrainted routes if constraints are specified', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/test', {}, (req, res) => {})
+  findMyWay.on('GET', '/test', { constraints: { host: 'example.com' } }, (req, res) => {})
+
+  findMyWay.off('GET', '/test', { host: 'example.com' })
+
+  t.equal(findMyWay.routes.length, 1)
+})
+
+test('off removes no routes if provided constraints does not match any registered route', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/test', {}, (req, res) => {})
+  findMyWay.on('GET', '/test', { constraints: { version: '2.x' } }, (req, res) => {})
+  findMyWay.on('GET', '/test', { constraints: { version: '3.x' } }, (req, res) => {})
+
+  findMyWay.off('GET', '/test', { version: '1.x' })
+
+  t.equal(findMyWay.routes.length, 3)
+})

--- a/test/regex.test.js
+++ b/test/regex.test.js
@@ -192,7 +192,7 @@ test('Should check if a regex is safe to use', t => {
     try {
       findMyWay.on('GET', `/test/:id(${regex.toString()})`, noop)
       t.pass('ok')
-      findMyWay.off('GET', `/test/:id(${regex.toString()})`, noop)
+      findMyWay.off('GET', `/test/:id(${regex.toString()})`)
     } catch (err) {
       t.fail(err)
     }
@@ -239,7 +239,7 @@ test('Disable safe regex check', t => {
     try {
       findMyWay.on('GET', `/test/:id(${regex.toString()})`, noop)
       t.pass('ok')
-      findMyWay.off('GET', `/test/:id(${regex.toString()})`, noop)
+      findMyWay.off('GET', `/test/:id(${regex.toString()})`)
     } catch (err) {
       t.fail(err)
     }
@@ -249,7 +249,7 @@ test('Disable safe regex check', t => {
     try {
       findMyWay.on('GET', `/test/:id(${regex.toString()})`, noop)
       t.pass('ok')
-      findMyWay.off('GET', `/test/:id(${regex.toString()})`, noop)
+      findMyWay.off('GET', `/test/:id(${regex.toString()})`)
     } catch (err) {
       t.fail(err)
     }


### PR DESCRIPTION
The `off` method had some bugs.

```js
const router = require('find-my-way')()

router.on('GET', '/test', {}, (req, res) => {})
router.on('GET', '/test', { constraints: { host: 'example.com' } }, (req, res) => {})

router.off('GET', '/test', { host: 'example.com' })

router.prettyPrint() // is empty
```

or

```js
const router = require('find-my-way')()

router.on('GET', '/test', {}, (req, res) => {})
router.on('GET', '/test', { constraints: { host: 'example.com' } }, (req, res) => {})

router.off('GET', '/test', { host: 'test.de' }) // only removes the route without constraint
```

The `off` method now implements the following logic:

1. `router.off` is called without constraints: Any route matching the provided method and path are removed regardless of the constraints
2. `router.off` is called with constraints: Only the route with the exact same constraints will be removed. Routes without constraints are not removed.  

In the regex.test.js file, the `off` method was called incorrectly, resulting in incorrect tests. This has been fixed as well.
