### PR TITLE
fix: using pre-defined http methods instead http module

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,16 +26,15 @@
 */
 
 const assert = require('assert')
-const http = require('http')
 const querystring = require('fast-querystring')
 const isRegexSafe = require('safe-regex2')
 const deepEqual = require('fast-deep-equal')
 const { flattenNode, compressFlattenedNode, prettyPrintFlattenedNode, prettyPrintRoutesArray } = require('./lib/pretty-print')
 const { StaticNode, NODE_TYPES } = require('./custom_node')
 const Constrainer = require('./lib/constrainer')
+const httpMethods = require('./lib/http-methods');
 const { safeDecodeURI, safeDecodeURIComponent } = require('./lib/url-sanitizer')
 
-const httpMethods = http.METHODS
 const FULL_PATH_REGEXP = /^https?:\/\/.*?\//
 const OPTIONAL_PARAM_REGEXP = /(\/:[^/()]*?)\?(\/?)/
 
@@ -594,10 +593,10 @@ Router.prototype.prettyPrint = function (opts = {}) {
   return prettyPrintFlattenedNode.call(this, root, '', true, opts)
 }
 
-for (var i in http.METHODS) {
+for (var i in httpMethods) {
   /* eslint no-prototype-builtins: "off" */
-  if (!http.METHODS.hasOwnProperty(i)) continue
-  const m = http.METHODS[i]
+  if (!httpMethods.hasOwnProperty(i)) continue
+  const m = httpMethods[i]
   const methodName = m.toLowerCase()
 
   if (Router.prototype[methodName]) throw new Error('Method already exists: ' + methodName)

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const deepEqual = require('fast-deep-equal')
 const { flattenNode, compressFlattenedNode, prettyPrintFlattenedNode, prettyPrintRoutesArray } = require('./lib/pretty-print')
 const { StaticNode, NODE_TYPES } = require('./custom_node')
 const Constrainer = require('./lib/constrainer')
-const httpMethods = require('./lib/http-methods');
+const httpMethods = require('./lib/http-methods')
 const { safeDecodeURI, safeDecodeURIComponent } = require('./lib/url-sanitizer')
 
 const FULL_PATH_REGEXP = /^https?:\/\/.*?\//

--- a/lib/http-methods.js
+++ b/lib/http-methods.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// defined by Node.js http module, a snapshot from Node.js 18.12.0
 const httpMethods = [
   'ACL', 'BIND', 'CHECKOUT', 'CONNECT', 'COPY', 'DELETE',
   'GET', 'HEAD', 'LINK', 'LOCK', 'M-SEARCH', 'MERGE',

--- a/lib/http-methods.js
+++ b/lib/http-methods.js
@@ -7,4 +7,4 @@ const httpMethods = [
   'UNBIND', 'UNLINK', 'UNLOCK', 'UNSUBSCRIBE'
 ]
 
-module.exports = httpMethods;
+module.exports = httpMethods

--- a/lib/http-methods.js
+++ b/lib/http-methods.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const httpMethods = [
   'ACL', 'BIND', 'CHECKOUT', 'CONNECT', 'COPY', 'DELETE',
   'GET', 'HEAD', 'LINK', 'LOCK', 'M-SEARCH', 'MERGE',

--- a/lib/http-methods.js
+++ b/lib/http-methods.js
@@ -1,0 +1,10 @@
+const httpMethods = [
+  'ACL', 'BIND', 'CHECKOUT', 'CONNECT', 'COPY', 'DELETE',
+  'GET', 'HEAD', 'LINK', 'LOCK', 'M-SEARCH', 'MERGE',
+  'MKACTIVITY', 'MKCALENDAR', 'MKCOL', 'MOVE', 'NOTIFY', 'OPTIONS',
+  'PATCH', 'POST', 'PROPFIND', 'PROPPATCH', 'PURGE', 'PUT',
+  'REBIND', 'REPORT', 'SEARCH', 'SOURCE', 'SUBSCRIBE', 'TRACE',
+  'UNBIND', 'UNLINK', 'UNLOCK', 'UNSUBSCRIBE'
+]
+
+module.exports = httpMethods;

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -743,10 +743,10 @@ test('register all known HTTP methods', t => {
   t.plan(6)
   const findMyWay = FindMyWay()
 
-  const http = require('http')
+  const httpMethods = require('../lib/http-methods')
   const handlers = {}
-  for (var i in http.METHODS) {
-    var m = http.METHODS[i]
+  for (var i in httpMethods) {
+    var m = httpMethods[i]
     handlers[m] = function myHandler () {}
     findMyWay.on(m, '/test', handlers[m])
   }

--- a/test/shorthands.test.js
+++ b/test/shorthands.test.js
@@ -1,15 +1,15 @@
 'use strict'
 
-const http = require('http')
+const httpMethods = require('../lib/http-methods')
 const t = require('tap')
 const test = t.test
 const FindMyWay = require('../')
 
 t.test('should support shorthand', t => {
-  t.plan(http.METHODS.length)
+  t.plan(httpMethods.length)
 
-  for (var i in http.METHODS) {
-    const m = http.METHODS[i]
+  for (var i in httpMethods) {
+    const m = httpMethods[i]
     const methodName = m.toLowerCase()
 
     t.test('`.' + methodName + '`', t => {


### PR DESCRIPTION
I would like to use find-my-way in an environment other than Node.js environment (Hybrid, Browser, etc.)

There is no problem with other modules because browserify polyfills are implemented, but in the find-my-way library, METHODS is imported from the http module, and no alternative polyfills exist.

To work around that issue, declare METHODS as a constant within find-my-way instead of importing it from the http module.