### PR TITLE
feat: use internal trees for prettyPrint

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ console.log(findMyWay.prettyPrint({ method: 'PUT' }))
 
 `prettyPrint` accepts an optional setting to print compressed routes. This is useful
 when you have a large number of routes with common prefixes. Doesn't represent the
-internal router structure. Don't use it for debugging.
+internal router structure. **Don't use it for debugging.**
 
 ```js
 console.log(findMyWay.prettyPrint({ commonPrefix: false }))

--- a/handler_storage.js
+++ b/handler_storage.js
@@ -16,12 +16,15 @@ class HandlerStorage {
     return this._getHandlerMatchingConstraints(derivedConstraints)
   }
 
-  addHandler (handler, params, store, constrainer, constraints) {
+  addHandler (constrainer, route) {
+    const params = route.params
+    const constraints = route.opts.constraints || {}
+
     const handlerObject = {
-      handler,
       params,
       constraints,
-      store: store || null,
+      handler: route.handler,
+      store: route.store || null,
       _createParamsObject: this._compileCreateParamsObject(params)
     }
 

--- a/handler_storage.js
+++ b/handler_storage.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const httpMethodStrategy = require('./lib/strategies/http-method')
+
 class HandlerStorage {
   constructor () {
     this.unconstrainedHandler = null // optimized reference to the handler that will match most of the time
@@ -28,11 +30,12 @@ class HandlerStorage {
       _createParamsObject: this._compileCreateParamsObject(params)
     }
 
-    if (Object.keys(constraints).length === 0) {
+    const constraintsNames = Object.keys(constraints)
+    if (constraintsNames.length === 0) {
       this.unconstrainedHandler = handlerObject
     }
 
-    for (const constraint of Object.keys(constraints)) {
+    for (const constraint of constraintsNames) {
       if (!this.constraints.includes(constraint)) {
         if (constraint === 'version') {
           // always check the version constraint first as it is the most selective
@@ -43,7 +46,8 @@ class HandlerStorage {
       }
     }
 
-    if (this.handlers.length >= 32) {
+    const isMergedTree = constraintsNames.includes(httpMethodStrategy.name)
+    if (!isMergedTree && this.handlers.length >= 32) {
       throw new Error('find-my-way supports a maximum of 32 route handlers per node when there are constraints, limit reached')
     }
 
@@ -51,7 +55,9 @@ class HandlerStorage {
     // Sort the most constrained handlers to the front of the list of handlers so they are tested first.
     this.handlers.sort((a, b) => Object.keys(a.constraints).length - Object.keys(b.constraints).length)
 
-    this._compileGetHandlerMatchingConstraints(constrainer, constraints)
+    if (!isMergedTree) {
+      this._compileGetHandlerMatchingConstraints(constrainer, constraints)
+    }
   }
 
   _compileCreateParamsObject (params) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -161,7 +161,11 @@ declare namespace Router {
 
     reset(): void;
     prettyPrint(): string;
-    prettyPrint(opts: { commonPrefix?: boolean, includeMeta?: boolean | (string | symbol)[]  }): string;
+    prettyPrint(opts: {
+      method?: HTTPMethod,
+      commonPrefix?: boolean,
+      includeMeta?: boolean | (string | symbol)[]
+    }): string;
 
     hasConstraintStrategy(strategyName: string): boolean;
     addConstraintStrategy(constraintStrategy: ConstraintStrategy<V>): void;

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -53,8 +53,11 @@ function serializeMeta (route, options) {
 
     const serializedKey = metaKey.toString()
     const metaValue = metaDataObject[metaKey]
-    const serializedValue = JSON.stringify(parseMeta(metaValue))
-    serializedMetaData += `\n• (${serializedKey}) ${serializedValue}`
+
+    if (metaValue !== undefined && metaValue !== null) {
+      const serializedValue = JSON.stringify(parseMeta(metaValue))
+      serializedMetaData += `\n• (${serializedKey}) ${serializedValue}`
+    }
   }
 
   return serializedMetaData

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const deepEqual = require('fast-deep-equal')
+
 const httpMethodStrategy = require('./strategies/http-method')
 const treeDataSymbol = Symbol('treeData')
 
@@ -38,10 +40,11 @@ function parseMeta (meta) {
   return meta
 }
 
-function serializeMeta (route, options) {
-  let serializedMetaData = ''
+function getRouteMetaData (route, options) {
+  if (!options.includeMeta) return {}
 
   const metaDataObject = options.buildPrettyMeta(route)
+  const filteredMetaData = {}
 
   let includeMetaKeys = options.includeMeta
   if (!Array.isArray(includeMetaKeys)) {
@@ -56,33 +59,74 @@ function serializeMeta (route, options) {
 
     if (metaValue !== undefined && metaValue !== null) {
       const serializedValue = JSON.stringify(parseMeta(metaValue))
-      serializedMetaData += `\n• (${serializedKey}) ${serializedValue}`
+      filteredMetaData[serializedKey] = serializedValue
     }
   }
 
+  return filteredMetaData
+}
+
+function serializeMetaData (metaData) {
+  let serializedMetaData = ''
+  for (const [key, value] of Object.entries(metaData)) {
+    serializedMetaData += `\n• (${key}) ${value}`
+  }
   return serializedMetaData
 }
 
-function serializeRoute (route, options) {
+// get original merged tree node route
+function normalizeRoute (route) {
   const constraints = { ...route.opts.constraints }
+  const method = constraints[httpMethodStrategy.name]
+  delete constraints[httpMethodStrategy.name]
+  return { ...route, method, opts: { constraints } }
+}
 
-  let method = options.method
-  if (method === undefined) {
-    method = constraints[httpMethodStrategy.name]
-    delete constraints[httpMethodStrategy.name]
-  }
+function serializeRoute (route) {
+  let serializedRoute = ` (${route.method})`
 
-  let handlerString = ` (${method})`
+  const constraints = route.opts.constraints || {}
   if (Object.keys(constraints).length !== 0) {
-    handlerString += ' ' + JSON.stringify(constraints)
+    serializedRoute += ' ' + JSON.stringify(constraints)
   }
 
-  if (options.includeMeta) {
-    const originRoute = { ...route, method, opts: { constraints } }
-    handlerString += serializeMeta(originRoute, options)
+  serializedRoute += serializeMetaData(route.metaData)
+  return serializedRoute
+}
+
+function mergeSimilarRoutes (routes) {
+  return routes.reduce((mergedRoutes, route) => {
+    for (const nodeRoute of mergedRoutes) {
+      if (
+        deepEqual(route.opts.constraints, nodeRoute.opts.constraints) &&
+        deepEqual(route.metaData, nodeRoute.metaData)
+      ) {
+        nodeRoute.method += ', ' + route.method
+        return mergedRoutes
+      }
+    }
+    mergedRoutes.push(route)
+    return mergedRoutes
+  }, [])
+}
+
+function serializeNode (node, prefix, options) {
+  let routes = node.routes
+
+  if (options.method === undefined) {
+    routes = routes.map(normalizeRoute)
   }
 
-  return handlerString
+  routes = routes.map(route => {
+    route.metaData = getRouteMetaData(route, options)
+    return route
+  })
+
+  if (options.method === undefined) {
+    routes = mergeSimilarRoutes(routes)
+  }
+
+  return routes.map(serializeRoute).join(`\n${prefix}`)
 }
 
 function buildObjectTree (node, tree, prefix, options) {
@@ -91,9 +135,7 @@ function buildObjectTree (node, tree, prefix, options) {
     tree = tree[prefix] = {}
 
     if (node.isLeafNode) {
-      tree[treeDataSymbol] = node.routes
-        .map(route => serializeRoute(route, options))
-        .join(`\n${prefix}`)
+      tree[treeDataSymbol] = serializeNode(node, prefix, options)
     }
 
     prefix = ''

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -1,14 +1,27 @@
 'use strict'
 
-/* eslint-disable no-multi-spaces */
-const indent              = '    '
-const branchIndent        = '│   '
-const midBranchIndent     = '├── '
-const endBranchIndent     = '└── '
-const wildcardDelimiter   = '*'
-const pathDelimiter       = '/'
-const pathRegExp          = /(?=\/)/
-/* eslint-enable */
+const httpMethodStrategy = require('./strategies/http-method')
+const treeDataSymbol = Symbol('treeData')
+
+function printObjectTree (obj, parentPrefix = '') {
+  let tree = ''
+  const keys = Object.keys(obj)
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i]
+    const value = obj[key]
+    const isLast = i === keys.length - 1
+
+    const nodePrefix = isLast ? '└── ' : '├── '
+    const childPrefix = isLast ? '    ' : '│   '
+
+    const nodeData = value[treeDataSymbol] || ''
+    const prefixedNodeData = nodeData.split('\n').join('\n' + parentPrefix + childPrefix)
+
+    tree += parentPrefix + nodePrefix + key + prefixedNodeData + '\n'
+    tree += printObjectTree(value, parentPrefix + childPrefix)
+  }
+  return tree
+}
 
 function parseFunctionName (fn) {
   let fName = fn.name || ''
@@ -25,295 +38,86 @@ function parseMeta (meta) {
   return meta
 }
 
-function buildMetaObject (route, metaArray) {
-  const out = {}
-  const cleanMeta = this.buildPrettyMeta(route)
-  if (!Array.isArray(metaArray)) metaArray = cleanMeta ? Reflect.ownKeys(cleanMeta) : []
-  metaArray.forEach(m => {
-    const metaKey = typeof m === 'symbol' ? m.toString() : m
-    if (cleanMeta && cleanMeta[m]) {
-      out[metaKey] = parseMeta(cleanMeta[m])
-    }
-  })
-  return out
+function serializeMeta (route, options) {
+  let serializedMetaData = ''
+
+  const metaDataObject = options.buildPrettyMeta(route)
+
+  let includeMetaKeys = options.includeMeta
+  if (!Array.isArray(includeMetaKeys)) {
+    includeMetaKeys = Reflect.ownKeys(metaDataObject)
+  }
+
+  for (const metaKey of includeMetaKeys) {
+    if (!Object.prototype.hasOwnProperty.call(metaDataObject, metaKey)) continue
+
+    const serializedKey = metaKey.toString()
+    const metaValue = metaDataObject[metaKey]
+    const serializedValue = JSON.stringify(parseMeta(metaValue))
+    serializedMetaData += `\n• (${serializedKey}) ${serializedValue}`
+  }
+
+  return serializedMetaData
 }
 
-function prettyPrintRoutesArray (routeArray, opts = {}) {
-  if (!this.buildPrettyMeta) throw new Error('buildPrettyMeta not defined')
-  opts.includeMeta = opts.includeMeta || null // array of meta objects to display
-  const mergedRouteArray = []
+function serializeRoute (route, options) {
+  const constraints = { ...route.opts.constraints }
 
-  let tree = ''
-
-  routeArray.sort((a, b) => {
-    if (!a.path || !b.path) return 0
-    return a.path.localeCompare(b.path)
-  })
-
-  // merge alike paths
-  for (let i = 0; i < routeArray.length; i++) {
-    const route = routeArray[i]
-    const pathExists = mergedRouteArray.find(r => route.path === r.path)
-    if (pathExists) {
-      // path already declared, add new method and break out of loop
-      pathExists.handlers.push({
-        method: route.method,
-        opts: route.opts.constraints || undefined,
-        meta: opts.includeMeta ? buildMetaObject.call(this, route, opts.includeMeta) : null
-      })
-      continue
-    }
-
-    const routeHandler = {
-      method: route.method,
-      opts: route.opts.constraints || undefined,
-      meta: opts.includeMeta ? buildMetaObject.call(this, route, opts.includeMeta) : null
-    }
-    mergedRouteArray.push({
-      path: route.path,
-      methods: [route.method],
-      opts: [route.opts],
-      handlers: [routeHandler]
-    })
+  let method = options.method
+  if (method === undefined) {
+    method = constraints[httpMethodStrategy.name]
+    delete constraints[httpMethodStrategy.name]
   }
 
-  // insert root level path if none defined
-  if (!mergedRouteArray.filter(r => r.path === pathDelimiter).length) {
-    const rootPath = {
-      path: pathDelimiter,
-      truncatedPath: '',
-      methods: [],
-      opts: [],
-      handlers: [{}]
-    }
-
-    // if wildcard route exists, insert root level after wildcard
-    if (mergedRouteArray.filter(r => r.path === wildcardDelimiter).length) {
-      mergedRouteArray.splice(1, 0, rootPath)
-    } else {
-      mergedRouteArray.unshift(rootPath)
-    }
+  let handlerString = ` (${method})`
+  if (Object.keys(constraints).length !== 0) {
+    handlerString += ' ' + JSON.stringify(constraints)
   }
 
-  // build tree
-  const routeTree = buildRouteTree(mergedRouteArray)
+  if (options.includeMeta) {
+    const originRoute = { ...route, method, opts: { constraints } }
+    handlerString += serializeMeta(originRoute, options)
+  }
 
-  // draw tree
-  routeTree.forEach((rootBranch, idx) => {
-    tree += drawBranch(rootBranch, null, idx === routeTree.length - 1, false, true)
-    tree += '\n' // newline characters inserted at beginning of drawing function to allow for nested paths
-  })
-
-  return tree
+  return handlerString
 }
 
-function buildRouteTree (mergedRouteArray) {
-  const result = []
-  const temp = { result }
-  mergedRouteArray.forEach((route, idx) => {
-    let splitPath = route.path.split(pathRegExp)
+function buildObjectTree (node, tree, prefix, options) {
+  if (node.isLeafNode || options.commonPrefix !== false) {
+    prefix = prefix || '(empty root node)'
+    tree = tree[prefix] = {}
 
-    // add preceding slash for proper nesting
-    if (splitPath[0] !== pathDelimiter) {
-      // handle wildcard route
-      if (splitPath[0] !== wildcardDelimiter) splitPath = [pathDelimiter, splitPath[0].slice(1), ...splitPath.slice(1)]
+    if (node.isLeafNode) {
+      tree[treeDataSymbol] = node.routes
+        .map(route => serializeRoute(route, options))
+        .join(`\n${prefix}`)
     }
 
-    // build tree
-    splitPath.reduce((acc, path, pidx) => {
-      if (!acc[path]) {
-        acc[path] = { result: [] }
-        const pathSeg = { path, children: acc[path].result }
-
-        if (pidx === splitPath.length - 1) pathSeg.handlers = route.handlers
-        acc.result.push(pathSeg)
-      }
-      return acc[path]
-    }, temp)
-  })
-
-  // unfold root object from array
-  return result
-}
-
-function drawBranch (pathSeg, prefix, endBranch, noPrefix, rootBranch) {
-  let branch = ''
-
-  if (!noPrefix && !rootBranch) branch += '\n'
-  if (!noPrefix) branch += `${prefix || ''}${endBranch ? endBranchIndent : midBranchIndent}`
-  branch += `${pathSeg.path}`
-
-  if (pathSeg.handlers) {
-    const flatHandlers = pathSeg.handlers.reduce((acc, curr) => {
-      const match = acc.findIndex(h => JSON.stringify(h.opts) === JSON.stringify(curr.opts))
-      if (match !== -1) {
-        acc[match].method = [acc[match].method, curr.method].join(', ')
-      } else {
-        acc.push(curr)
-      }
-      return acc
-    }, [])
-
-    flatHandlers.forEach((handler, idx) => {
-      if (idx > 0) branch += `${noPrefix ? '' : prefix || ''}${endBranch ? indent : branchIndent}${pathSeg.path}`
-      branch += ` (${handler.method || '-'})`
-      if (handler.opts && JSON.stringify(handler.opts) !== '{}') branch += ` ${JSON.stringify(handler.opts)}`
-      if (handler.meta) {
-        Reflect.ownKeys(handler.meta).forEach((m, hidx) => {
-          branch += `\n${noPrefix ? '' : prefix || ''}${endBranch ? indent : branchIndent}`
-          branch += `• (${m}) ${JSON.stringify(handler.meta[m])}`
-        })
-      }
-      if (flatHandlers.length > 1 && idx !== flatHandlers.length - 1) branch += '\n'
-    })
-  } else {
-    if (pathSeg.children.length > 1) branch += ' (-)'
-  }
-
-  if (!noPrefix) prefix = `${prefix || ''}${endBranch ? indent : branchIndent}`
-
-  pathSeg.children.forEach((child, idx) => {
-    const endBranch = idx === pathSeg.children.length - 1
-    const skipPrefix = (!pathSeg.handlers && pathSeg.children.length === 1)
-    branch += drawBranch(child, prefix, endBranch, skipPrefix)
-  })
-
-  return branch
-}
-
-function prettyPrintFlattenedNode (flattenedNode, prefix, tail, opts) {
-  if (!this.buildPrettyMeta) throw new Error('buildPrettyMeta not defined')
-  opts.includeMeta = opts.includeMeta || null // array of meta items to display
-  let paramName = ''
-  const printHandlers = []
-
-  for (const { node, method } of flattenedNode.nodes) {
-    for (const handler of node.handlerStorage.handlers) {
-      printHandlers.push({ method, ...handler })
-    }
-  }
-
-  if (printHandlers.length) {
-    printHandlers.forEach((handler, index) => {
-      let suffix = `(${handler.method || '-'})`
-      if (Object.keys(handler.constraints).length > 0) {
-        suffix += ' ' + JSON.stringify(handler.constraints)
-      }
-
-      let name = ''
-      // find locations of parameters in prefix
-      const paramIndices = flattenedNode.prefix.split('').map((ch, idx) => ch === ':' ? idx : null).filter(idx => idx !== null)
-      if (paramIndices.length) {
-        let prevLoc = 0
-        paramIndices.forEach((loc, idx) => {
-          // find parameter in prefix
-          name += flattenedNode.prefix.slice(prevLoc, loc + 1)
-          // insert parameters
-          name += handler.params[handler.params.length - paramIndices.length + idx]
-          if (idx === paramIndices.length - 1) name += flattenedNode.prefix.slice(loc + 1)
-          prevLoc = loc + 1
-        })
-      } else {
-        // there are no parameters, return full object
-        name = flattenedNode.prefix
-      }
-
-      if (index === 0) {
-        paramName += `${name} ${suffix}`
-      } else {
-        paramName += `\n${prefix}${tail ? indent : branchIndent}${name} ${suffix}`
-      }
-      if (opts.includeMeta) {
-        const meta = buildMetaObject.call(this, handler, opts.includeMeta)
-        Object.keys(meta).forEach((m, hidx) => {
-          paramName += `\n${prefix || ''}${tail ? indent : branchIndent}`
-          paramName += `• (${m}) ${JSON.stringify(meta[m])}`
-        })
-      }
-    })
-  } else {
-    paramName = flattenedNode.prefix
-  }
-
-  let tree = `${prefix}${tail ? endBranchIndent : midBranchIndent}${paramName}\n`
-
-  prefix = `${prefix}${tail ? indent : branchIndent}`
-  const labels = Object.keys(flattenedNode.children)
-  for (let i = 0; i < labels.length; i++) {
-    const child = flattenedNode.children[labels[i]]
-    tree += prettyPrintFlattenedNode.call(this, child, prefix, i === (labels.length - 1), opts)
-  }
-  return tree
-}
-
-function flattenNode (flattened, node, method) {
-  if (node.handlerStorage.handlers.length !== 0) {
-    flattened.nodes.push({ method, node })
-  }
-
-  if (node.parametricChildren && node.parametricChildren[0]) {
-    if (!flattened.children[':']) {
-      flattened.children[':'] = {
-        prefix: ':',
-        nodes: [],
-        children: {}
-      }
-    }
-    flattenNode(flattened.children[':'], node.parametricChildren[0], method)
-  }
-
-  if (node.wildcardChild) {
-    if (!flattened.children['*']) {
-      flattened.children['*'] = {
-        prefix: '*',
-        nodes: [],
-        children: {}
-      }
-    }
-    flattenNode(flattened.children['*'], node.wildcardChild, method)
+    prefix = ''
   }
 
   if (node.staticChildren) {
     for (const child of Object.values(node.staticChildren)) {
-      // split on the slash separator but use a regex to lookahead and not actually match it, preserving it in the returned string segments
-      const childPrefixSegments = child.prefix.split(pathRegExp)
-      let cursor = flattened
-      let parent
-      for (const segment of childPrefixSegments) {
-        parent = cursor
-        cursor = cursor.children[segment]
-        if (!cursor) {
-          cursor = {
-            prefix: segment,
-            nodes: [],
-            children: {}
-          }
-          parent.children[segment] = cursor
-        }
-      }
-      flattenNode(cursor, child, method)
-    }
-  }
-}
-
-function compressFlattenedNode (flattenedNode) {
-  const childKeys = Object.keys(flattenedNode.children)
-  if (flattenedNode.nodes.length === 0 && childKeys.length === 1) {
-    const child = flattenedNode.children[childKeys[0]]
-    if (child.nodes.length <= 1) {
-      compressFlattenedNode(child)
-      flattenedNode.nodes = child.nodes
-      flattenedNode.prefix += child.prefix
-      flattenedNode.children = child.children
-      return flattenedNode
+      buildObjectTree(child, tree, prefix + child.prefix, options)
     }
   }
 
-  for (const key of Object.keys(flattenedNode.children)) {
-    compressFlattenedNode(flattenedNode.children[key])
+  if (node.parametricChildren) {
+    for (const child of Object.values(node.parametricChildren)) {
+      const childPrefix = Array.from(child.nodePaths).join('|')
+      buildObjectTree(child, tree, prefix + childPrefix, options)
+    }
   }
 
-  return flattenedNode
+  if (node.wildcardChild) {
+    buildObjectTree(node.wildcardChild, tree, '*', options)
+  }
 }
 
-module.exports = { flattenNode, compressFlattenedNode, prettyPrintFlattenedNode, prettyPrintRoutesArray }
+function prettyPrintTree (root, options) {
+  const objectTree = {}
+  buildObjectTree(root, objectTree, root.prefix, options)
+  return printObjectTree(objectTree)
+}
+
+module.exports = { prettyPrintTree }

--- a/lib/strategies/http-method.js
+++ b/lib/strategies/http-method.js
@@ -1,0 +1,17 @@
+'use strict'
+
+module.exports = {
+  name: '__fmw_internal_strategy_merged_tree_http_method__',
+  storage: function () {
+    const handlers = {}
+    return {
+      get: (type) => { return handlers[type] || null },
+      set: (type, store) => { handlers[type] = store }
+    }
+  },
+  deriveConstraint: (req) => {
+    /* istanbul ignore next */
+    return req.method
+  },
+  mustMatchWhenDerived: true
+}

--- a/test/pretty-print-tree.test.js
+++ b/test/pretty-print-tree.test.js
@@ -12,7 +12,7 @@ test('pretty print - static routes', t => {
   findMyWay.on('GET', '/test/hello', () => {})
   findMyWay.on('GET', '/hello/world', () => {})
 
-  const tree = findMyWay.prettyPrint()
+  const tree = findMyWay.prettyPrint({ method: 'GET' })
   const expected = `\
 └── /
     ├── test (GET)
@@ -31,7 +31,7 @@ test('pretty print - parametric routes', t => {
   findMyWay.on('GET', '/test/:hello', () => {})
   findMyWay.on('GET', '/hello/:world', () => {})
 
-  const tree = findMyWay.prettyPrint()
+  const tree = findMyWay.prettyPrint({ method: 'GET' })
   const expected = `\
 └── /
     ├── test (GET)
@@ -54,7 +54,7 @@ test('pretty print - parametric routes', t => {
   findMyWay.on('GET', '/static/:param(123).end/suffix3', () => {})
   findMyWay.on('GET', '/static/:param1(123).:param2(456)/suffix4', () => {})
 
-  const tree = findMyWay.prettyPrint()
+  const tree = findMyWay.prettyPrint({ method: 'GET' })
   const expected = `\
 └── /
     └── static (GET)
@@ -82,7 +82,7 @@ test('pretty print - parametric routes', t => {
   findMyWay.on('GET', '/static/:param(123).end/suffix3', () => {})
   findMyWay.on('GET', '/static/:param1(123).:param2(456)/suffix4', () => {})
 
-  const tree = findMyWay.prettyPrint({ commonPrefix: false })
+  const tree = findMyWay.prettyPrint({ method: 'GET', commonPrefix: false })
   const expected = `\
 └── /static (GET)
     ├── /:param(123).end/suffix3 (GET)
@@ -103,13 +103,12 @@ test('pretty print - mixed parametric routes', t => {
   findMyWay.on('POST', '/test/:hello', () => {})
   findMyWay.on('GET', '/test/:hello/world', () => {})
 
-  const tree = findMyWay.prettyPrint()
+  const tree = findMyWay.prettyPrint({ method: 'GET' })
   const expected = `\
 └── /
     └── test (GET)
         └── /
             └── :hello (GET)
-                :hello (POST)
                 └── /world (GET)
 `
   t.equal(typeof tree, 'string')
@@ -124,7 +123,7 @@ test('pretty print - wildcard routes', t => {
   findMyWay.on('GET', '/test/*', () => {})
   findMyWay.on('GET', '/hello/*', () => {})
 
-  const tree = findMyWay.prettyPrint()
+  const tree = findMyWay.prettyPrint({ method: 'GET' })
   const expected = `\
 └── /
     ├── test (GET)
@@ -146,14 +145,13 @@ test('pretty print - parametric routes with same parent and followed by a static
   findMyWay.on('POST', '/test/hello/:id', () => {})
   findMyWay.on('GET', '/test/helloworld', () => {})
 
-  const tree = findMyWay.prettyPrint()
+  const tree = findMyWay.prettyPrint({ method: 'GET' })
   const expected = `\
 └── /
     └── test (GET)
         └── /hello
             ├── /
             │   └── :id (GET)
-            │       :id (POST)
             └── world (GET)
 `
   t.equal(typeof tree, 'string')
@@ -170,7 +168,7 @@ test('pretty print - constrained parametric routes', t => {
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '1.1.2' } }, () => {})
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '2.0.0' } }, () => {})
 
-  const tree = findMyWay.prettyPrint()
+  const tree = findMyWay.prettyPrint({ method: 'GET' })
   const expected = `\
 └── /
     └── test (GET)
@@ -194,28 +192,7 @@ test('pretty print - multiple parameters are drawn appropriately', t => {
   findMyWay.on('GET', '/test/:hello/there/:ladies/and/:gents', () => {})
   findMyWay.on('GET', '/test/are/:you/:ready/to/:rock', () => {})
 
-  const tree = findMyWay.prettyPrint({ commonPrefix: false })
-  const expected = `\
-└── /test (GET)
-    ├── /are/:you/:ready/to/:rock (GET)
-    └── /:hello/there/:ladies (GET)
-        └── /and/:gents (GET)
-`
-  t.equal(typeof tree, 'string')
-  t.equal(tree, expected)
-})
-
-test('pretty print - multiple parameters are drawn appropriately', t => {
-  t.plan(2)
-
-  const findMyWay = FindMyWay()
-  findMyWay.on('GET', '/test', () => {})
-  // routes with a nested parameter (i.e. no handler for the /:param) were breaking the display
-  findMyWay.on('GET', '/test/:hello/there/:ladies', () => {})
-  findMyWay.on('GET', '/test/:hello/there/:ladies/and/:gents', () => {})
-  findMyWay.on('GET', '/test/are/:you/:ready/to/:rock', () => {})
-
-  const tree = findMyWay.prettyPrint({ commonPrefix: false })
+  const tree = findMyWay.prettyPrint({ method: 'GET', commonPrefix: false })
   const expected = `\
 └── /test (GET)
     ├── /are/:you/:ready/to/:rock (GET)
@@ -235,10 +212,10 @@ test('pretty print commonPrefix - use routes array to draw flattened routes', t 
   findMyWay.on('GET', '/test/hello', () => {})
   findMyWay.on('GET', '/testing', () => {})
   findMyWay.on('GET', '/testing/:param', () => {})
-  findMyWay.on('PUT', '/update', () => {})
+  findMyWay.on('GET', '/update', () => {})
 
-  const radixTree = findMyWay.prettyPrint({ commonPrefix: true })
-  const arrayTree = findMyWay.prettyPrint({ commonPrefix: false })
+  const radixTree = findMyWay.prettyPrint({ method: 'GET', commonPrefix: true })
+  const arrayTree = findMyWay.prettyPrint({ method: 'GET', commonPrefix: false })
 
   const radixExpected = `\
 └── /
@@ -247,7 +224,7 @@ test('pretty print commonPrefix - use routes array to draw flattened routes', t 
     │   └── ing (GET)
     │       └── /
     │           └── :param (GET)
-    └── update (PUT)
+    └── update (GET)
 `
 
   const arrayExpected = `\
@@ -255,7 +232,7 @@ test('pretty print commonPrefix - use routes array to draw flattened routes', t 
 │   ├── /hello (GET)
 │   └── ing (GET)
 │       └── /:param (GET)
-└── /update (PUT)
+└── /update (GET)
 `
 
   t.equal(typeof radixTree, 'string')
@@ -270,19 +247,18 @@ test('pretty print commonPrefix - handle wildcard root', t => {
 
   const findMyWay = FindMyWay()
 
-  findMyWay.on('OPTIONS', '*', () => {})
+  findMyWay.on('GET', '*', () => {})
   findMyWay.on('GET', '/test/hello', () => {})
   findMyWay.on('GET', '/testing', () => {})
   findMyWay.on('GET', '/testing/:param', () => {})
   findMyWay.on('PUT', '/update', () => {})
 
-  const arrayTree = findMyWay.prettyPrint({ commonPrefix: false })
+  const arrayTree = findMyWay.prettyPrint({ method: 'GET', commonPrefix: false })
   const arrayExpected = `\
 ├── /test/hello (GET)
 ├── /testing (GET)
 │   └── /:param (GET)
-├── /update (PUT)
-└── * (OPTIONS)
+└── * (GET)
 `
   t.equal(typeof arrayTree, 'string')
   t.equal(arrayTree, arrayExpected)
@@ -299,16 +275,15 @@ test('pretty print commonPrefix - handle wildcard root', t => {
   findMyWay.on('GET', '/testing/:param', () => {})
   findMyWay.on('PUT', '/update', () => {})
 
-  const radixTree = findMyWay.prettyPrint()
+  const radixTree = findMyWay.prettyPrint({ method: 'GET' })
   const radixExpected = `\
 └── (empty root node)
     ├── /
-    │   ├── test
-    │   │   ├── /hello (GET)
-    │   │   └── ing (GET)
-    │   │       └── /
-    │   │           └── :param (GET)
-    │   └── update (PUT)
+    │   └── test
+    │       ├── /hello (GET)
+    │       └── ing (GET)
+    │           └── /
+    │               └── :param (GET)
     └── * (GET)
 `
   t.equal(typeof radixTree, 'string')
@@ -327,55 +302,13 @@ test('pretty print commonPrefix - handle constrained routes', t => {
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '1.1.2' } }, () => {})
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '2.0.0' } }, () => {})
 
-  const arrayTree = findMyWay.prettyPrint({ commonPrefix: false })
+  const arrayTree = findMyWay.prettyPrint({ method: 'GET', commonPrefix: false })
   const arrayExpected = `\
 └── /test (GET)
     /test (GET) {"host":"auth.fastify.io"}
     └── /:hello (GET)
-        /:hello (PUT)
         /:hello (GET) {"version":"1.1.2"}
         /:hello (GET) {"version":"2.0.0"}
-`
-  t.equal(typeof arrayTree, 'string')
-  t.equal(arrayTree, arrayExpected)
-})
-
-test('pretty print commonPrefix - handle method constraint', t => {
-  t.plan(2)
-
-  const findMyWay = FindMyWay()
-  findMyWay.addConstraintStrategy({
-    name: 'method',
-    storage: function () {
-      const handlers = {}
-      return {
-        get: (type) => { return handlers[type] || null },
-        set: (type, store) => { handlers[type] = store }
-      }
-    },
-    deriveConstraint: (req) => req.headers['x-method'],
-    mustMatchWhenDerived: true
-  })
-
-  findMyWay.on('GET', '/test', () => {})
-  findMyWay.on('GET', '/test', { constraints: { method: 'foo' } }, () => {})
-  findMyWay.on('GET', '/test/:hello', () => {})
-  findMyWay.on('PUT', '/test/:hello', () => {})
-  findMyWay.on('GET', '/test/:hello', { constraints: { method: 'bar' } }, () => {})
-  findMyWay.on('GET', '/test/:hello', { constraints: { method: 'baz' } }, () => {})
-
-  const arrayTree = findMyWay.prettyPrint({
-    commonPrefix: false,
-    methodConstraintName: 'methodOverride'
-  })
-
-  const arrayExpected = `\
-└── /test (GET)
-    /test (GET) {"method":"foo"}
-    └── /:hello (GET)
-        /:hello (PUT)
-        /:hello (GET) {"method":"bar"}
-        /:hello (GET) {"method":"baz"}
 `
   t.equal(typeof arrayTree, 'string')
   t.equal(arrayTree, arrayExpected)
@@ -404,7 +337,11 @@ test('pretty print includeMeta - commonPrefix: true', t => {
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '1.1.2' } }, () => {})
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '2.0.0' } }, () => {})
 
-  const radixTree = findMyWay.prettyPrint({ commonPrefix: true, includeMeta: true })
+  const radixTree = findMyWay.prettyPrint({
+    method: 'GET',
+    commonPrefix: true,
+    includeMeta: true
+  })
   const radixTreeExpected = `\
 └── /
     └── test (GET)
@@ -432,20 +369,15 @@ test('pretty print includeMeta - commonPrefix: true', t => {
         │       • (objectMeta) {"one":"1","two":2}
         │       • (functionMeta) "namedFunction()"
         │       • (Symbol(symbolKey)) "Symbol(symbolValue)"
-        ├── ed/
-        │   └── :hello (PUT)
-        │       • (onRequest) ["anonymous()","namedFunction()"]
-        │       • (onTimeout) ["anonymous()"]
-        │       • (genericMeta) "meta"
-        │       • (mixedMeta) ["mixed items",{"an":"object"}]
-        │       • (objectMeta) {"one":"1","two":2}
-        │       • (functionMeta) "namedFunction()"
-        │       • (Symbol(symbolKey)) "Symbol(symbolValue)"
         └── /
             └── :hello (GET) {"version":"1.1.2"}
                 :hello (GET) {"version":"2.0.0"}
 `
-  const radixTreeSpecific = findMyWay.prettyPrint({ commonPrefix: true, includeMeta: ['onTimeout', 'objectMeta', 'nonExistent'] })
+  const radixTreeSpecific = findMyWay.prettyPrint({
+    method: 'GET',
+    commonPrefix: true,
+    includeMeta: ['onTimeout', 'objectMeta', 'nonExistent']
+  })
   const radixTreeSpecificExpected = `\
 └── /
     └── test (GET)
@@ -458,23 +390,21 @@ test('pretty print includeMeta - commonPrefix: true', t => {
         │   └── :hello (GET)
         │       • (onTimeout) ["anonymous()"]
         │       • (objectMeta) {"one":"1","two":2}
-        ├── ed/
-        │   └── :hello (PUT)
-        │       • (onTimeout) ["anonymous()"]
-        │       • (objectMeta) {"one":"1","two":2}
         └── /
             └── :hello (GET) {"version":"1.1.2"}
                 :hello (GET) {"version":"2.0.0"}
 `
-  const radixTreeNoMeta = findMyWay.prettyPrint({ commonPrefix: true, includeMeta: false })
+  const radixTreeNoMeta = findMyWay.prettyPrint({
+    method: 'GET',
+    commonPrefix: true,
+    includeMeta: false
+  })
   const radixTreeNoMetaExpected = `\
 └── /
     └── test (GET)
         test (GET) {"host":"auth.fastify.io"}
         ├── ing/
         │   └── :hello (GET)
-        ├── ed/
-        │   └── :hello (PUT)
         └── /
             └── :hello (GET) {"version":"1.1.2"}
                 :hello (GET) {"version":"2.0.0"}
@@ -512,7 +442,11 @@ test('pretty print includeMeta - commonPrefix: false', t => {
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '1.1.2' } }, () => {})
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '2.0.0' } }, () => {})
 
-  const arrayTree = findMyWay.prettyPrint({ commonPrefix: false, includeMeta: true })
+  const arrayTree = findMyWay.prettyPrint({
+    method: 'GET',
+    commonPrefix: false,
+    includeMeta: true
+  })
   const arrayExpected = `\
 └── /test (GET)
     • (onRequest) ["anonymous()","namedFunction()"]
@@ -538,18 +472,14 @@ test('pretty print includeMeta - commonPrefix: false', t => {
     │   • (objectMeta) {"one":"1","two":2}
     │   • (functionMeta) "namedFunction()"
     │   • (Symbol(symbolKey)) "Symbol(symbolValue)"
-    ├── ed/:hello (PUT)
-    │   • (onRequest) ["anonymous()","namedFunction()"]
-    │   • (onTimeout) ["anonymous()"]
-    │   • (genericMeta) "meta"
-    │   • (mixedMeta) ["mixed items",{"an":"object"}]
-    │   • (objectMeta) {"one":"1","two":2}
-    │   • (functionMeta) "namedFunction()"
-    │   • (Symbol(symbolKey)) "Symbol(symbolValue)"
     └── /:hello (GET) {"version":"1.1.2"}
         /:hello (GET) {"version":"2.0.0"}
 `
-  const arraySpecific = findMyWay.prettyPrint({ commonPrefix: false, includeMeta: ['onRequest', 'mixedMeta', 'nonExistent'] })
+  const arraySpecific = findMyWay.prettyPrint({
+    method: 'GET',
+    commonPrefix: false,
+    includeMeta: ['onRequest', 'mixedMeta', 'nonExistent']
+  })
   const arraySpecificExpected = `\
 └── /test (GET)
     • (onRequest) ["anonymous()","namedFunction()"]
@@ -560,18 +490,18 @@ test('pretty print includeMeta - commonPrefix: false', t => {
     ├── ing/:hello (GET)
     │   • (onRequest) ["anonymous()","namedFunction()"]
     │   • (mixedMeta) ["mixed items",{"an":"object"}]
-    ├── ed/:hello (PUT)
-    │   • (onRequest) ["anonymous()","namedFunction()"]
-    │   • (mixedMeta) ["mixed items",{"an":"object"}]
     └── /:hello (GET) {"version":"1.1.2"}
         /:hello (GET) {"version":"2.0.0"}
 `
-  const arrayNoMeta = findMyWay.prettyPrint({ commonPrefix: false, includeMeta: false })
+  const arrayNoMeta = findMyWay.prettyPrint({
+    method: 'GET',
+    commonPrefix: false,
+    includeMeta: false
+  })
   const arrayNoMetaExpected = `\
 └── /test (GET)
     /test (GET) {"host":"auth.fastify.io"}
     ├── ing/:hello (GET)
-    ├── ed/:hello (PUT)
     └── /:hello (GET) {"version":"1.1.2"}
         /:hello (GET) {"version":"2.0.0"}
 `
@@ -613,7 +543,11 @@ test('pretty print includeMeta - buildPrettyMeta function', t => {
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '1.1.2' } }, () => {})
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '2.0.0' } }, () => {})
 
-  const arrayTree = findMyWay.prettyPrint({ commonPrefix: false, includeMeta: true })
+  const arrayTree = findMyWay.prettyPrint({
+    method: 'GET',
+    commonPrefix: false,
+    includeMeta: true
+  })
   const arrayExpected = `\
 └── /test (GET)
     • (metaKey) "/test"
@@ -621,14 +555,15 @@ test('pretty print includeMeta - buildPrettyMeta function', t => {
     • (metaKey) "/test"
     └── /:hello (GET)
         • (metaKey) "/test/:hello"
-        /:hello (PUT)
-        • (metaKey) "not a GET route"
         /:hello (GET) {"version":"1.1.2"}
         • (metaKey) "/test/:hello"
         /:hello (GET) {"version":"2.0.0"}
         • (metaKey) "/test/:hello"
 `
-  const radixTree = findMyWay.prettyPrint({ includeMeta: true })
+  const radixTree = findMyWay.prettyPrint({
+    method: 'GET',
+    includeMeta: true
+  })
   const radixExpected = `\
 └── /
     └── test (GET)
@@ -638,8 +573,6 @@ test('pretty print includeMeta - buildPrettyMeta function', t => {
         └── /
             └── :hello (GET)
                 • (metaKey) "/test/:hello"
-                :hello (PUT)
-                • (metaKey) "not a GET route"
                 :hello (GET) {"version":"1.1.2"}
                 • (metaKey) "/test/:hello"
                 :hello (GET) {"version":"2.0.0"}

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -497,6 +497,8 @@ test('pretty print includeMeta - commonPrefix: false', t => {
   const store = {
     onRequest: [() => {}, namedFunction],
     onTimeout: [() => {}],
+    onError: null,
+    onRegister: undefined,
     genericMeta: 'meta',
     mixedMeta: ['mixed items', { an: 'object' }],
     objectMeta: { one: '1', two: 2 },

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -650,3 +650,21 @@ test('pretty print includeMeta - buildPrettyMeta function', t => {
   t.equal(typeof radixTree, 'string')
   t.equal(radixTree, radixExpected)
 })
+
+test('pretty print - print all methods', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay()
+  findMyWay.all('/test', () => {})
+
+  const tree = findMyWay.prettyPrint()
+  const expected = `\
+└── /
+    └── test (ACL, BIND, CHECKOUT, CONNECT, COPY, DELETE, GET, HEAD, LINK, LOCK, \
+M-SEARCH, MERGE, MKACTIVITY, MKCALENDAR, MKCOL, MOVE, NOTIFY, OPTIONS, PATCH, \
+POST, PROPFIND, PROPPATCH, PURGE, PUT, REBIND, REPORT, SEARCH, SOURCE, SUBSCRIBE, \
+TRACE, UNBIND, UNLINK, UNLOCK, UNSUBSCRIBE)
+`
+  t.equal(typeof tree, 'string')
+  t.equal(tree, expected)
+})

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -108,8 +108,7 @@ test('pretty print - mixed parametric routes', t => {
 └── /
     └── test (GET)
         └── /
-            └── :hello (GET)
-                :hello (POST)
+            └── :hello (GET, POST)
                 └── /world (GET)
 `
   t.equal(typeof tree, 'string')
@@ -152,8 +151,7 @@ test('pretty print - parametric routes with same parent and followed by a static
     └── test (GET)
         └── /hello
             ├── /
-            │   └── :id (GET)
-            │       :id (POST)
+            │   └── :id (GET, POST)
             └── world (GET)
 `
   t.equal(typeof tree, 'string')
@@ -331,8 +329,7 @@ test('pretty print commonPrefix - handle constrained routes', t => {
   const arrayExpected = `\
 └── /test (GET)
     /test (GET) {"host":"auth.fastify.io"}
-    └── /:hello (GET)
-        /:hello (PUT)
+    └── /:hello (GET, PUT)
         /:hello (GET) {"version":"1.1.2"}
         /:hello (GET) {"version":"2.0.0"}
 `
@@ -372,8 +369,7 @@ test('pretty print commonPrefix - handle method constraint', t => {
   const arrayExpected = `\
 └── /test (GET)
     /test (GET) {"method":"foo"}
-    └── /:hello (GET)
-        /:hello (PUT)
+    └── /:hello (GET, PUT)
         /:hello (GET) {"method":"bar"}
         /:hello (GET) {"method":"baz"}
 `
@@ -593,7 +589,7 @@ test('pretty print includeMeta - buildPrettyMeta function', t => {
 
   const findMyWay = FindMyWay({
     buildPrettyMeta: route => {
-      return { metaKey: route.method === 'GET' ? route.path : 'not a GET route' }
+      return { metaKey: route.method === 'PUT' ? 'Hide PUT route path' : route.path }
     }
   })
   const namedFunction = () => {}
@@ -612,6 +608,7 @@ test('pretty print includeMeta - buildPrettyMeta function', t => {
   findMyWay.on('GET', '/test', { constraints: { host: 'auth.fastify.io' } }, () => {}, store)
   findMyWay.on('GET', '/test/:hello', () => {}, store)
   findMyWay.on('PUT', '/test/:hello', () => {}, store)
+  findMyWay.on('POST', '/test/:hello', () => {}, store)
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '1.1.2' } }, () => {})
   findMyWay.on('GET', '/test/:hello', { constraints: { version: '2.0.0' } }, () => {})
 
@@ -621,10 +618,10 @@ test('pretty print includeMeta - buildPrettyMeta function', t => {
     • (metaKey) "/test"
     /test (GET) {"host":"auth.fastify.io"}
     • (metaKey) "/test"
-    └── /:hello (GET)
+    └── /:hello (GET, POST)
         • (metaKey) "/test/:hello"
         /:hello (PUT)
-        • (metaKey) "not a GET route"
+        • (metaKey) "Hide PUT route path"
         /:hello (GET) {"version":"1.1.2"}
         • (metaKey) "/test/:hello"
         /:hello (GET) {"version":"2.0.0"}
@@ -638,10 +635,10 @@ test('pretty print includeMeta - buildPrettyMeta function', t => {
         test (GET) {"host":"auth.fastify.io"}
         • (metaKey) "/test"
         └── /
-            └── :hello (GET)
+            └── :hello (GET, POST)
                 • (metaKey) "/test/:hello"
                 :hello (PUT)
-                • (metaKey) "not a GET route"
+                • (metaKey) "Hide PUT route path"
                 :hello (GET) {"version":"1.1.2"}
                 • (metaKey) "/test/:hello"
                 :hello (GET) {"version":"2.0.0"}

--- a/test/routes-registered.test.js
+++ b/test/routes-registered.test.js
@@ -21,7 +21,7 @@ test('verify routes registered', t => {
   findMyWay = initializeRoutes(findMyWay, defaultHandler, quantity)
   t.equal(findMyWay.routes.length, quantity)
   findMyWay.routes.map((route, idx) => {
-    t.same(route, {
+    t.match(route, {
       method: 'GET',
       path: '/test-route-' + idx,
       opts: {},

--- a/test/types/router.test-d.ts
+++ b/test/types/router.test-d.ts
@@ -57,6 +57,7 @@ let http2Res!: Http2ServerResponse;
 
   expectType<void>(router.reset())
   expectType<string>(router.prettyPrint())
+  expectType<string>(router.prettyPrint({ method: 'GET' }))
   expectType<string>(router.prettyPrint({ commonPrefix: false }))
   expectType<string>(router.prettyPrint({ commonPrefix: true }))
   expectType<string>(router.prettyPrint({ includeMeta: true }))


### PR DESCRIPTION
Fix: #315, #316, #271, #82

Problem: `prettyPrint` builds trees from scratch with a different algorithm. You can't use it for debugging and you always need to keep real trees and printed trees synced. It's literally another small router nested into the big one.

Solution: don't emulate the trees. I added a new option to the `prettyPrint` function: `method`. If you pass it, fmw will print you an internal tree. If you don't pass it, fmw will create a new router, merge all trees with a constraint hack, and will print the merged tree.

The logic of `commonPrefix: false` will be a little bit different.

\+ a lot of bug fixing, refactoring

❗ It will require regenerating prettyPrint tests in Fastify. Mostly because of bug fixing.

cc @climba03003 @Eomm @mcollina 