### PR TITLE
Add package.json "files" entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "Crazy fast http radix based router",
   "main": "index.js",
   "types": "index.d.ts",
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "lib"
+  ],
   "scripts": {
     "bench": "node ./benchmark/bench.js",
     "bench:cmp": "node ./benchmark/compare-branches.js",


### PR DESCRIPTION
I realize using `"files"` in `package.json` essentially inverts how files are allowed into the published library, but it significantly reduces the size on disk for `find-my-way` (yes already small, but could be super small 😎 ).

```diff
npm notice === Tarball Details === 
npm notice name:          find-my-way                             
npm notice version:       7.6.2                                   
npm notice filename:      find-my-way-7.6.2.tgz                   
- npm notice package size:  79.4 kB
- npm notice unpacked size: 378.0 kB
- npm notice total files:   89
+ npm notice package size:  24.3 kB
+ npm notice unpacked size: 88.9 kB
+ npm notice total files:   14
```

The files that are packaged look correct to me, but here's a list

```
LICENSE                         
README.md                       
index.d.ts                      
index.js                        
lib/constrainer.js              
lib/handler-storage.js          
lib/http-methods.js             
lib/node.js                     
lib/pretty-print.js             
lib/strategies/accept-host.js   
lib/strategies/accept-version.js
lib/strategies/http-method.js   
lib/url-sanitizer.js            
package.json
```

fixes #327
Happy to hear feedback/make changes