### PR TITLE
chore: `npm run test` failing due to standard

### DIFF
--- a/index.js
+++ b/index.js
@@ -584,7 +584,7 @@ Router.prototype.prettyPrint = function (options = {}) {
   return prettyPrintTree(tree, options)
 }
 
-for (var i in httpMethods) {
+for (const i in httpMethods) {
   /* eslint no-prototype-builtins: "off" */
   if (!httpMethods.hasOwnProperty(i)) continue
   const m = httpMethods[i]
@@ -636,7 +636,7 @@ function getClosingParenthensePosition (path, idx) {
   // but it's inefficient for grouped or wrong regexp expressions.
   // see issues #62 and #63 for more info
 
-  var parentheses = 1
+  let parentheses = 1
 
   while (idx < path.length) {
     idx++

--- a/test/methods.test.js
+++ b/test/methods.test.js
@@ -126,12 +126,12 @@ test('off with nested wildcards with parametric and static', t => {
   findMyWay.on('GET', '/foo3/*', () => {})
   findMyWay.on('GET', '/foo4/param/hello/test/long/route', () => {})
 
-  var route1 = findMyWay.find('GET', '/foo3/first/second')
+  const route1 = findMyWay.find('GET', '/foo3/first/second')
   t.equal(route1.params['*'], 'first/second')
 
   findMyWay.off('GET', '/foo3/*')
 
-  var route2 = findMyWay.find('GET', '/foo3/first/second')
+  const route2 = findMyWay.find('GET', '/foo3/first/second')
   t.equal(route2.params['*'], '/foo3/first/second')
 
   findMyWay.off('GET', '/foo2/*')
@@ -672,7 +672,7 @@ test('parametric route with different method', t => {
 test('params does not keep the object reference', t => {
   t.plan(2)
   const findMyWay = FindMyWay()
-  var first = true
+  let first = true
 
   findMyWay.on('GET', '/test/:id', (req, res, params) => {
     if (first) {
@@ -745,8 +745,8 @@ test('register all known HTTP methods', t => {
 
   const httpMethods = require('../lib/http-methods')
   const handlers = {}
-  for (var i in httpMethods) {
-    var m = httpMethods[i]
+  for (const i in httpMethods) {
+    const m = httpMethods[i]
     handlers[m] = function myHandler () {}
     findMyWay.on(m, '/test', handlers[m])
   }

--- a/test/routes-registered.test.js
+++ b/test/routes-registered.test.js
@@ -20,7 +20,7 @@ test('verify routes registered', t => {
 
   findMyWay = initializeRoutes(findMyWay, defaultHandler, quantity)
   t.equal(findMyWay.routes.length, quantity)
-  findMyWay.routes.map((route, idx) => {
+  findMyWay.routes.forEach((route, idx) => {
     t.match(route, {
       method: 'GET',
       path: '/test-route-' + idx,

--- a/test/shorthands.test.js
+++ b/test/shorthands.test.js
@@ -8,7 +8,7 @@ const FindMyWay = require('../')
 t.test('should support shorthand', t => {
   t.plan(httpMethods.length)
 
-  for (var i in httpMethods) {
+  for (const i in httpMethods) {
     const m = httpMethods[i]
     const methodName = m.toLowerCase()
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -33,7 +33,7 @@ test('find a store object', t => {
 test('update the store', t => {
   t.plan(2)
   const findMyWay = FindMyWay()
-  var bool = false
+  let bool = false
 
   findMyWay.on('GET', '/test', (req, res, params, store) => {
     if (!bool) {


### PR DESCRIPTION
Cloned main today, tried `npm run test`, failed with a few errors that went away with `standard --fix` and one error that required change from `.map` to `.forEach`.

First contribution here but doesn't seem to have broken anything and  `npm run test` now running.