### PR TITLE
perf: improve string operations

### DIFF
--- a/benchmark/compare-branches.js
+++ b/benchmark/compare-branches.js
@@ -47,14 +47,13 @@ async function executeCommandOnBranch (command, branch) {
 function parseBenchmarksStdout (text) {
   const results = []
 
-  const lines = text.split('\n')
-  for (const line of lines) {
+  for (const line of text.split('\n')) {
     const match = /^(.+?)(\.*) x (.+) ops\/sec .*$/.exec(line)
     if (match !== null) {
       results.push({
         name: match[1],
         alignedName: match[1] + match[2],
-        result: parseInt(match[3].split(',').join(''))
+        result: parseInt(match[3].replaceAll(',', ''))
       })
     }
   }

--- a/index.js
+++ b/index.js
@@ -184,8 +184,8 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
       if (!this.caseSensitive) {
         staticNodePath = staticNodePath.toLowerCase()
       }
-      staticNodePath = staticNodePath.split('::').join(':')
-      staticNodePath = staticNodePath.split('%').join('%25')
+      staticNodePath = staticNodePath.replaceAll('::', ':')
+      staticNodePath = staticNodePath.replaceAll('%', '%25')
       // add the static part of the route to the tree
       currentNode = currentNode.createStaticChild(staticNodePath)
     }
@@ -240,8 +240,8 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
 
           let staticPart = pattern.slice(staticPartStartIndex, j)
           if (staticPart) {
-            staticPart = staticPart.split('::').join(':')
-            staticPart = staticPart.split('%').join('%25')
+            staticPart = staticPart.replaceAll('::', ':')
+            staticPart = staticPart.replaceAll('%', '%25')
             regexps.push(backtrack = escapeRegExp(staticPart))
           }
 
@@ -328,8 +328,8 @@ Router.prototype.findRoute = function findNode (method, path, constraints = {}) 
       if (!this.caseSensitive) {
         staticNodePath = staticNodePath.toLowerCase()
       }
-      staticNodePath = staticNodePath.split('::').join(':')
-      staticNodePath = staticNodePath.split('%').join('%25')
+      staticNodePath = staticNodePath.replaceAll('::', ':')
+      staticNodePath = staticNodePath.replaceAll('%', '%25')
       // add the static part of the route to the tree
       currentNode = currentNode.getStaticChild(staticNodePath)
       if (currentNode === null) {
@@ -387,8 +387,8 @@ Router.prototype.findRoute = function findNode (method, path, constraints = {}) 
 
           let staticPart = pattern.slice(staticPartStartIndex, j)
           if (staticPart) {
-            staticPart = staticPart.split('::').join(':')
-            staticPart = staticPart.split('%').join('%25')
+            staticPart = staticPart.replaceAll('::', ':')
+            staticPart = staticPart.replaceAll('%', '%25')
             regexps.push(backtrack = escapeRegExp(staticPart))
           }
 

--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -17,7 +17,7 @@ function printObjectTree (obj, parentPrefix = '') {
     const childPrefix = isLast ? '    ' : '│   '
 
     const nodeData = value[treeDataSymbol] || ''
-    const prefixedNodeData = nodeData.split('\n').join('\n' + parentPrefix + childPrefix)
+    const prefixedNodeData = nodeData.replaceAll('\n', '\n' + parentPrefix + childPrefix)
 
     tree += parentPrefix + nodePrefix + key + prefixedNodeData + '\n'
     tree += printObjectTree(value, parentPrefix + childPrefix)

--- a/lib/strategies/accept-version.js
+++ b/lib/strategies/accept-version.js
@@ -18,7 +18,7 @@ SemVerStore.prototype.set = function (version, store) {
   if (typeof version !== 'string') {
     throw new TypeError('Version should be a string')
   }
-  let [major, minor, patch] = version.split('.')
+  let [major, minor, patch] = version.split('.', 3)
 
   if (isNaN(major)) {
     throw new TypeError('Major version must be a numeric value')


### PR DESCRIPTION
`str.split('a').join('b')` creates an intermediary array and is slower than `.replaceAll`, which immediately replaces the patterns without creating an array, `.replaceAll` has been available in Node.js since v15

Vanilla benchmark results:
```sh
Results:
VM142:51 ----------------------------------------
VM142:52 split().join() average time: 0.0020ms
VM142:53 replaceAll() average time: 0.0012ms
VM142:54 Difference: 0.0008ms
VM142:55 replaceAll() is faster by 40.00%

Results:
VM142:51 ----------------------------------------
VM142:52 split().join() average time: 0.0065ms
VM142:53 replaceAll() average time: 0.0034ms
VM142:54 Difference: 0.0031ms
VM142:55 replaceAll() is faster by 47.69%

Results:
VM142:51 ----------------------------------------
VM142:52 split().join() average time: 0.0416ms
VM142:53 replaceAll() average time: 0.0216ms
VM142:54 Difference: 0.0200ms
VM142:55 replaceAll() is faster by 48.08%
```


```js
function generateRandomString(length) {
    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
    let result = '';
    for (let i = 0; i < length; i++) {
        result += characters.charAt(Math.floor(Math.random() * characters.length));
    }
    return result;
}

function runBenchmark(iterations, stringLength) {
    const results = {
        splitJoin: [],
        replaceAll: []
    };
    
    const testStrings = Array(iterations).fill(null).map(() => {
        const str = generateRandomString(stringLength);
        return str.replaceAll('a', 'X').replaceAll('b', 'X').replaceAll('c', 'X');
    });
    
    console.log(`Running benchmark with ${iterations} iterations on strings of length ${stringLength}`);
    console.log('----------------------------------------');
    
    console.log('Testing split().join()...');
    for (let i = 0; i < iterations; i++) {
        const startTime = performance.now();
        testStrings[i].split('X').join('Y');
        const endTime = performance.now();
        results.splitJoin.push(endTime - startTime);
    }
    
    console.log('Testing replaceAll()...');
    for (let i = 0; i < iterations; i++) {
        const startTime = performance.now();
        testStrings[i].replaceAll('X', 'Y');
        const endTime = performance.now();
        results.replaceAll.push(endTime - startTime);
    }
    
    const splitJoinAvg = results.splitJoin.reduce((a, b) => a + b, 0) / iterations;
    const replaceAllAvg = results.replaceAll.reduce((a, b) => a + b, 0) / iterations;
    
    console.log('\nResults:');
    console.log('----------------------------------------');
    console.log(`split().join() average time: ${splitJoinAvg.toFixed(4)}ms`);
    console.log(`replaceAll() average time: ${replaceAllAvg.toFixed(4)}ms`);
    console.log(`Difference: ${Math.abs(splitJoinAvg - replaceAllAvg).toFixed(4)}ms`);
    console.log(`${splitJoinAvg < replaceAllAvg ? 'split().join()' : 'replaceAll()'} is faster by ${((Math.abs(splitJoinAvg - replaceAllAvg) / Math.max(splitJoinAvg, replaceAllAvg)) * 100).toFixed(2)}%`);
    
    return {
        splitJoinAvg,
        replaceAllAvg,
        difference: Math.abs(splitJoinAvg - replaceAllAvg),
        percentageDifference: ((Math.abs(splitJoinAvg - replaceAllAvg) / Math.max(splitJoinAvg, replaceAllAvg)) * 100)
    };
}

const smallTest = runBenchmark(1000, 100);
console.log('\n');
const mediumTest = runBenchmark(1000, 1000);
console.log('\n');
const largeTest = runBenchmark(1000, 10000);
```