### PR TITLE
perf: use map for sting-based stores

### DIFF
--- a/lib/strategies/accept-host.js
+++ b/lib/strategies/accept-host.js
@@ -2,11 +2,11 @@
 const assert = require('node:assert')
 
 function HostStorage () {
-  const hosts = {}
+  const hosts = new Map()
   const regexHosts = []
   return {
     get: (host) => {
-      const exact = hosts[host]
+      const exact = hosts.get(host)
       if (exact) {
         return exact
       }
@@ -20,7 +20,7 @@ function HostStorage () {
       if (host instanceof RegExp) {
         regexHosts.push({ host, value })
       } else {
-        hosts[host] = value
+        hosts.set(host, value)
       }
     }
   }

--- a/lib/strategies/accept-version.js
+++ b/lib/strategies/accept-version.js
@@ -7,8 +7,7 @@ function SemVerStore () {
     return new SemVerStore()
   }
 
-  this.store = {}
-
+  this.store = new Map()
   this.maxMajor = 0
   this.maxMinors = {}
   this.maxPatches = {}
@@ -30,29 +29,29 @@ SemVerStore.prototype.set = function (version, store) {
 
   if (major >= this.maxMajor) {
     this.maxMajor = major
-    this.store.x = store
-    this.store['*'] = store
-    this.store['x.x'] = store
-    this.store['x.x.x'] = store
+    this.store.set('x', store)
+    this.store.set('*', store)
+    this.store.set('x.x', store)
+    this.store.set('x.x.x', store)
   }
 
   if (minor >= (this.maxMinors[major] || 0)) {
     this.maxMinors[major] = minor
-    this.store[`${major}.x`] = store
-    this.store[`${major}.x.x`] = store
+    this.store.set(`${major}.x`, store)
+    this.store.set(`${major}.x.x`, store)
   }
 
   if (patch >= (this.maxPatches[`${major}.${minor}`] || 0)) {
     this.maxPatches[`${major}.${minor}`] = patch
-    this.store[`${major}.${minor}.x`] = store
+    this.store.set(`${major}.${minor}.x`, store)
   }
 
-  this.store[`${major}.${minor}.${patch}`] = store
+  this.store.set(`${major}.${minor}.${patch}`, store)
   return this
 }
 
 SemVerStore.prototype.get = function (version) {
-  return this.store[version]
+  return this.store.get(version)
 }
 
 module.exports = {

--- a/lib/strategies/http-method.js
+++ b/lib/strategies/http-method.js
@@ -3,10 +3,10 @@
 module.exports = {
   name: '__fmw_internal_strategy_merged_tree_http_method__',
   storage: function () {
-    const handlers = {}
+    const handlers = new Map()
     return {
-      get: (type) => { return handlers[type] || null },
-      set: (type, store) => { handlers[type] = store }
+      get: (type) => { return handlers.get(type) || null },
+      set: (type, store) => { handlers.set(type, store) }
     }
   },
   /* c8 ignore next 1 */


### PR DESCRIPTION
When an object is used as a map and has string-based keys, Map's performance will be superior

For this repo, not sure how to test it but here's some related discussion and benchmarks in https://github.com/kibertoad/toad-cache/issues/40

And a V8 engineer explaining why: https://stackoverflow.com/questions/62350146/why-map-manipulation-is-much-slower-than-object-in-javascript-v8-for-integ/62351925#62351925