### PR TITLE
perf: refactor escapeRegExp and removeDuplicateSlashes functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -769,7 +769,7 @@ function escapeRegExp (string) {
 }
 
 function removeDuplicateSlashes (path) {
-  return path.includes('//') ? path.replace(REMOVE_DUPLICATE_SLASHES_REGEXP, '/') : path
+  return path.indexOf('//') !== -1 ? path.replace(REMOVE_DUPLICATE_SLASHES_REGEXP, '/') : path
 }
 
 function trimLastSlash (path) {

--- a/index.js
+++ b/index.js
@@ -38,6 +38,8 @@ const { safeDecodeURI, safeDecodeURIComponent } = require('./lib/url-sanitizer')
 
 const FULL_PATH_REGEXP = /^https?:\/\/.*?\//
 const OPTIONAL_PARAM_REGEXP = /(\/:[^/()]*?)\?(\/?)/
+const ESCAPE_REGEXP = /[.*+?^${}()|[\]\\]/g
+const REMOVE_DUPLICATE_SLASHES_REGEXP = /\/\/+/g
 
 if (!isRegexSafe(FULL_PATH_REGEXP)) {
   throw new Error('the FULL_PATH_REGEXP is not safe, update this module')
@@ -45,6 +47,14 @@ if (!isRegexSafe(FULL_PATH_REGEXP)) {
 
 if (!isRegexSafe(OPTIONAL_PARAM_REGEXP)) {
   throw new Error('the OPTIONAL_PARAM_REGEXP is not safe, update this module')
+}
+
+if (!isRegexSafe(ESCAPE_REGEXP)) {
+  throw new Error('the ESCAPE_REGEXP is not safe, update this module')
+}
+
+if (!isRegexSafe(REMOVE_DUPLICATE_SLASHES_REGEXP)) {
+  throw new Error('the REMOVE_DUPLICATE_SLASHES_REGEXP is not safe, update this module')
 }
 
 function Router (opts) {
@@ -755,11 +765,11 @@ Router.prototype.all = function (path, handler, store) {
 module.exports = Router
 
 function escapeRegExp (string) {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return string.replace(ESCAPE_REGEXP, '\\$&')
 }
 
 function removeDuplicateSlashes (path) {
-  return path.replace(/\/\/+/g, '/')
+  return path.includes('//') ? path.replace(REMOVE_DUPLICATE_SLASHES_REGEXP, '/') : path
 }
 
 function trimLastSlash (path) {


### PR DESCRIPTION
Before

```
lookup root "/" route.................................... x 48,077,482 ops/sec ±0.59% (589 runs sampled)
lookup short static route................................ x 31,420,706 ops/sec ±0.52% (592 runs sampled)
lookup long static route................................. x 9,783,174 ops/sec ±0.25% (595 runs sampled)
lookup long static route (common prefix)................. x 7,271,538 ops/sec ±0.36% (594 runs sampled)
lookup short parametric route............................ x 21,064,272 ops/sec ±0.32% (592 runs sampled)
lookup long parametric route............................. x 12,880,641 ops/sec ±0.36% (591 runs sampled)
lookup short parametric route (encoded unoptimized)...... x 12,994,657 ops/sec ±0.35% (593 runs sampled)
lookup short parametric route (encoded optimized)........ x 8,996,853 ops/sec ±0.40% (590 runs sampled)
lookup parametric route with two short params............ x 10,970,106 ops/sec ±0.39% (591 runs sampled)
lookup multi-parametric route with two short params...... x 9,585,064 ops/sec ±0.28% (592 runs sampled)
lookup multi-parametric route with two short regex params x 10,459,247 ops/sec ±0.45% (592 runs sampled)
lookup long static + parametric route.................... x 5,947,666 ops/sec ±0.37% (594 runs sampled)
lookup short wildcard route.............................. x 24,819,735 ops/sec ±0.32% (590 runs sampled)
lookup long wildcard route............................... x 13,710,667 ops/sec ±0.39% (592 runs sampled)
lookup root route on constrained router.................. x 40,353,726 ops/sec ±0.57% (588 runs sampled)
lookup short static unconstraint route................... x 28,506,795 ops/sec ±0.32% (591 runs sampled)
lookup short static versioned route...................... x 22,672,929 ops/sec ±0.37% (592 runs sampled)
lookup short static constrained (version & host) route... x 18,306,216 ops/sec ±0.32% (592 runs sampled)
```

After

```
lookup root "/" route.................................... x 49,289,785 ops/sec ±0.57% (590 runs sampled)
lookup short static route................................ x 32,207,219 ops/sec ±0.34% (593 runs sampled)
lookup long static route................................. x 9,958,308 ops/sec ±0.15% (595 runs sampled)
lookup long static route (common prefix)................. x 7,327,772 ops/sec ±0.17% (595 runs sampled)
lookup short parametric route............................ x 22,236,338 ops/sec ±0.24% (594 runs sampled)
lookup long parametric route............................. x 13,338,765 ops/sec ±0.16% (594 runs sampled)
lookup short parametric route (encoded unoptimized)...... x 13,677,878 ops/sec ±0.18% (594 runs sampled)
lookup short parametric route (encoded optimized)........ x 9,521,347 ops/sec ±0.17% (595 runs sampled)
lookup parametric route with two short params............ x 11,394,921 ops/sec ±0.20% (594 runs sampled)
lookup multi-parametric route with two short params...... x 9,974,175 ops/sec ±0.19% (595 runs sampled)
lookup multi-parametric route with two short regex params x 10,799,743 ops/sec ±0.19% (596 runs sampled)
lookup long static + parametric route.................... x 6,328,150 ops/sec ±0.18% (595 runs sampled)
lookup short wildcard route.............................. x 25,555,634 ops/sec ±0.29% (594 runs sampled)
lookup long wildcard route............................... x 13,058,604 ops/sec ±0.21% (595 runs sampled)
lookup root route on constrained router.................. x 42,586,465 ops/sec ±0.47% (590 runs sampled)
lookup short static unconstraint route................... x 29,844,847 ops/sec ±0.35% (591 runs sampled)
lookup short static versioned route...................... x 23,460,870 ops/sec ±0.32% (593 runs sampled)
lookup short static constrained (version & host) route... x 18,947,685 ops/sec ±0.20% (595 runs sampled)
```

Closes https://github.com/delvedor/find-my-way/issues/318