### PR TITLE
ci(node.js): update workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,21 +24,21 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
-        exclude:
-          - os: windows-latest
-            node-version: 22 
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
+        check-latest: true
         node-version: ${{ matrix.node-version }}
 
     - name: Install
       run: |
-        npm install
+        npm install --ignore-scripts
 
     - name: Lint
       run: |


### PR DESCRIPTION
This PR:

-   Removes Git credentials after checkout as a security precaution by setting `persist-credentials` to false. They are not used after the initial checkout, and this stops them from accidentally leaking through a script; [see related GitHub security post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) and [related actions/checkout issue](https://github.com/actions/checkout/issues/485)
-   Set `check-latest` to true, so that the `actions/setup-node` will check it is using the latest minor or hotfix Node version and use that instead of its cached version, this stops an issue like with 22.5.0 that introduced a regression and actions were still using that instead of 22.5.1
     - Node 22.5.0 was why Windows 22 was excluded to begin with, which has now been unexcluded
-  Adds `--ignore-scripts` arg to `npm install` calls, preventing any potentially harmful lifecycle scripts that may have snuck in