### PR TITLE
build(dependabot): reduce npm updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       # Prefix all commit messages with "chore: "
       prefix: "chore"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
     groups:
       # Production dependencies without breaking changes


### PR DESCRIPTION
Similar reasoning as https://github.com/fastify/fastify/pull/5939, find-my-way doesn't get released on a regular schedule for this to be needed.