### PR TITLE
ci(node.js): pin actions to commit-hash

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,12 +26,12 @@ jobs:
           - macOS-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         check-latest: true
         node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
After what has been happening with [tj-actions/changed-files](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) over the past week this is probably a sensible idea.

[See related blog post by rafaelgss about pinning to the commit-hash](https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash).