### PR TITLE
perf: optimize bitmask handler retrieval using Math.clz32

### DIFF
--- a/lib/handler-storage.js
+++ b/lib/handler-storage.js
@@ -165,8 +165,8 @@ class HandlerStorage {
       }
     }
 
-    // Return the first handler who's bit is set in the candidates https://stackoverflow.com/questions/18134985/how-to-find-index-of-first-set-bit
-    lines.push('return this.handlers[Math.floor(Math.log2(candidates))]')
+    // Return the highest set bit index in the candidates bitmask.
+    lines.push('return this.handlers[31 - Math.clz32(candidates)]')
 
     this._getHandlerMatchingConstraints = new Function('derivedConstraints', lines.join('\n')) // eslint-disable-line
   }


### PR DESCRIPTION
This is [faster](https://perf.link/#eyJpZCI6ImZpc3drMGd4cmQwIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSBbLi4uQXJyYXkoMTAwMCkua2V5cygpXSIsInRlc3RzIjpbeyJuYW1lIjoiRmluZCBpdGVtIDEwMCIsImNvZGUiOiJNYXRoLmZsb29yKE1hdGgubG9nMihkYXRhLmxlbmd0aCkpIiwicnVucyI6WzI0OTgwMDAsNDQxMzAwMCw4MjgwMDAsNDI4MzAwMCw2ODczMDAwLDI2MDgwMDAsNzkzNzAwMCwzMTI4MDAwLDQ5NzMwMDAsNjk5ODAwMCwxMDc2MDAwLDExOTAwMCwxMTc1NjAwMCwxMzExMDAwLDEwMTI2MDAwLDE1ODIwMDAsNDE2NzAwMCwzNzk1MDAwLDU4NDQwMDAsNzk4NzAwMCwxMTExMDAwLDcwNTQwMDAsNjcwNTAwMCw1MDM0MDAwLDg1ODgwMDAsMTY1MDAwLDYyNDIwMDAsODkwODAwMCw2MTQ4MDAwLDU0MDIwMDAsNzE4OTAwMCwyMTQwMDAsNjgzNjAwMCw1MjE5MDAwLDQ3MDcwMDAsMzYzMjAwMCw3MzUyMDAwLDkxODAwMCw1NjE3MDAwLDI5NzMwMDAsNjQ0MzAwMCwzNDA3MDAwLDExNTU1MDAwLDY3NzIwMDAsNTc1MTAwMCw3NTQwMDAwLDY0MjMwMDAsMjQ3MDAwLDEwMjQ1MDAwLDUxMTgwMDAsNDU0NzAwMCw5NDcxMDAwLDMxNjAwMCw1MTc3MDAwLDQyOTcwMDAsNjUxMTAwMCw2MTE5MDAwLDgwMzUwMDAsMjM0MDAwLDc3NjgwMDAsNjEyOTAwMCw4MDE2MDAwLDEwMDY3MDAwLDkzMTIwMDAsMzkwMzAwMCw3MzY2MDAwLDY3MjcwMDAsNTk2MTAwMCw5NjY1MDAwLDEwNzYwMDAsOTQ0MDAwMCw2OTU2MDAwLDU2NjYwMDAsODQzODAwMCwxNTE1NDAwMCw0NjQ5MDAwLDg0MDQwMDAsNTMzNzAwMCw5Mjg5MDAwLDI4NDMwMDAsMjU5MjAwMCw4NzQ5MDAwLDQ2MDUwMDAsMTYzMTAwMCwyMTU0MDAwLDgzMTYwMDAsMzczNzAwMCw3ODc5MDAwLDQ2OTEwMDAsODIwMDAwMCw2NzUwMDAsNTkxMjAwMCw4NjU3MDAwLDQ0NTIwMDAsODEyOTAwMCw1Njg3MDAwLDE0NzUxMDAwLDQ1MDMwMDAsODEzOTAwMCw0ODM4MDAwXSwib3BzIjo1NzA5ODcwfSx7Im5hbWUiOiJGaW5kIGl0ZW0gMjAwIiwiY29kZSI6IjMxIC0gTWF0aC5jbHozMihkYXRhLmxlbmd0aCkiLCJydW5zIjpbMzQ5MzAwMCw1MjMxMDAwLDQ1MTAwMCw1ODM5MDAwLDkzOTYwMDAsMzI0NTAwMCwxMDg4NzAwMCw0MzM0MDAwLDY1NzcwMDAsMTA0NjQwMDAsMTE0MjAwMCwxNTMwMDAsMTUzMjEwMDAsMTY3MTAwMCwxMzA2MzAwMCwyMDgyMDAwLDU5OTkwMDAsNjAyNzAwMCw3MzI4MDAwLDEwODEzMDAwLDE1MTkwMDAsOTExMzAwMCw4ODg2MDAwLDY2ODUwMDAsMTEyNDEwMDAsMjE0MDAwLDc3ODMwMDAsMTE1NjEwMDAsODIwMTAwMCw3NTIyMDAwLDk1NzcwMDAsMjc4MDAwLDkzMDcwMDAsNjc5NDAwMCw2NDE2MDAwLDQwMDcwMDAsOTg4ODAwMCwxMTQyMDAwLDcwNjAwMDAsNDA3NzAwMCw4NDA1MDAwLDcyNzQwMDAsMTQzNTMwMDAsOTA4NzAwMCw3NzM2MDAwLDEwMjg0MDAwLDg1NzMwMDAsMzIyMDAwLDEzODYwMDAwLDY1MTEwMDAsNTY5NzAwMCwxMTY0NDAwMCw0MTMwMDAsNzAzODAwMCw2MTgzMDAwLDg0NDEwMDAsNzk0NzAwMCwxMDMzOTAwMCwzMDUwMDAsMTAyMTgwMDAsNzgzMjAwMCwxMDc3MTAwMCwxMzEzMjAwMCwxMjA2MTAwMCw1MTcyMDAwLDk0NDUwMDAsOTU4NTAwMCw3ODA4MDAwLDEyOTcyMDAwLDEzMDEwMDAsMTI1ODQwMDAsOTExMjAwMCw3MTYyMDAwLDExMjUzMDAwLDE5MDM4MDAwLDU3OTkwMDAsMTAzNTIwMDAsNzI4NjAwMCwxMjQ1MTAwMCwyODczMDAwLDMzMzEwMDAsMTE5MDkwMDAsNjkwODAwMCwyMTc1MDAwLDM1MTQwMDAsMTExNTMwMDAsNDY3MDAwMCwxMDgxNjAwMCw2MjQwMDAwLDEwNTE1MDAwLDg4MjAwMCw3MzY0MDAwLDExMzMyMDAwLDU2OTMwMDAsMTA1NzIwMDAsNzYxMjAwMCwxODg2MjAwMCw2MDU3MDAwLDEwMzc4MDAwLDY5NjAwMDBdLCJvcHMiOjc1NDM0OTB9XSwidXBkYXRlZCI6IjIwMjYtMDMtMjFUMTk6NDA6MDQuNDEyWiJ9) and has the same behavior for 32 bit bitmask

The following benches should be affected (but maybe not that much as they are dominated by other things):

  - lookup root route on constrained router
  - lookup short static unconstraint route
  - lookup short static versioned route
  - lookup short static constrained (version & host) route

I saw this:

branch:

```
lookup short static versioned route...................... x 13,751,685 ops/sec ±0.43% (595 runs sampled)
lookup short static constrained (version & host) route... x 13,870,414 ops/sec ±0.25% (595 runs sampled)
```

master:

```
lookup short static versioned route...................... x 12,528,508 ops/sec ±0.15% (596 runs sampled)
lookup short static constrained (version & host) route... x 10,737,182 ops/sec ±0.25% (596 runs sampled)
```