### PR TITLE
fix: default pathOptional to '/' when deregistering root optional params

### DIFF
--- a/index.js
+++ b/index.js
@@ -487,7 +487,7 @@ Router.prototype.off = function off (method, path, constraints) {
     assert(path.length === optionalParamMatch.index + optionalParamMatch[0].length, 'Optional Parameter needs to be the last parameter of the path')
 
     const pathFull = path.replace(OPTIONAL_PARAM_REGEXP, '$1$2')
-    const pathOptional = path.replace(OPTIONAL_PARAM_REGEXP, '$2')
+    const pathOptional = path.replace(OPTIONAL_PARAM_REGEXP, '$2') || '/'
 
     this.off(method, pathFull, constraints)
     this.off(method, pathOptional, constraints)

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -214,3 +214,15 @@ test('optional parameter on root', (t) => {
   findMyWay.lookup({ method: 'GET', url: '/', headers: {} }, null)
   findMyWay.lookup({ method: 'GET', url: '/foo', headers: {} }, null)
 })
+
+test('deregister a route with optional parameter on root', (t) => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/:optional?', (req, res, params) => {})
+
+  findMyWay.off('GET', '/:optional?')
+
+  t.assert.ok(!findMyWay.find('GET', '/'))
+  t.assert.ok(!findMyWay.find('GET', '/foo'))
+})


### PR DESCRIPTION
The `off` method replaced the optional parameter in the path but did not fall back to '/' when the resulting string was empty, unlike `on`. For paths like `/:param?`, `off` threw "The path could not be empty" instead of removing the route registered at '/'.