### PR TITLE
fix: align isParamSafe state in findRoute with _on

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,7 +378,7 @@ Router.prototype.findRoute = function findNode (method, path, constraints = {}) 
             regexps.push(trimRegExpStartAndEnd(regexString))
 
             j = endOfRegexIndex + 1
-            isParamSafe = false
+            isParamSafe = true
           } else {
             regexps.push(isParamSafe ? '(.*?)' : `(${backtrack}|(?:(?!${backtrack}).)*)`)
             isParamSafe = false

--- a/test/find-route.test.js
+++ b/test/find-route.test.js
@@ -179,6 +179,23 @@ test('findRoute returns null for a multi-parametric route', (t) => {
   equalRouters(t, findMyWay, fundMyWayClone)
 })
 
+test('findRoute returns handler for a regex + non-regex multi-param route', (t) => {
+  t.plan(8)
+
+  const findMyWay = FindMyWay()
+
+  const handler = () => {}
+  findMyWay.on('GET', '/:name(\\d+)-:other', handler)
+
+  const fundMyWayClone = rfdc(findMyWay)
+
+  const route = findMyWay.findRoute('GET', '/:name(\\d+)-:other')
+  t.assert.equal(route.handler, handler)
+  t.assert.deepEqual(route.params, ['name', 'other'])
+
+  equalRouters(t, findMyWay, fundMyWayClone)
+})
+
 test('findRoute returns handler and regexp param for a regexp route', (t) => {
   t.plan(8)
 


### PR DESCRIPTION
In findRoute, isParamSafe was set to false after processing a regex parameter, while _on sets it to true in the same position. The inconsistency caused the two methods to generate different regexes for routes that mix regex and non-regex params in one segment (e.g. '/:name(\\d+)-:other'), so getParametricChild could not match the node registered by _on and findRoute/hasRoute returned null.