### PR TITLE
fix: prevent done from being called multiple times on async constraint errors

### DIFF
--- a/lib/constrainer.js
+++ b/lib/constrainer.js
@@ -123,11 +123,15 @@ class Constrainer {
       return
     }
 
+    let errored = false
     constraints = constraints || {}
     for (const key of this.asyncStrategiesInUse) {
       const strategy = this.strategies[key]
       strategy.deriveConstraint(req, ctx, (err, constraintValue) => {
+        if (errored) return
+
         if (err !== null) {
+          errored = true
           done(err)
           return
         }

--- a/test/constraint.custom.async.test.js
+++ b/test/constraint.custom.async.test.js
@@ -70,6 +70,50 @@ test('lookup should return an error from deriveConstraint', t => {
   )
 })
 
+test('should call done only once when multiple async constraints error', (t, testDone) => {
+  t.plan(3)
+
+  const erroringConstraint = {
+    name: 'erroring',
+    storage: function () {
+      const store = {}
+      return {
+        get: (key) => store[key] || null,
+        set: (key, value) => { store[key] = value }
+      }
+    },
+    deriveConstraint: (req, ctx, done) => {
+      done(new Error('boom'))
+    }
+  }
+
+  const erroringConstraint2 = rfdc(erroringConstraint)
+  erroringConstraint2.name = 'erroring2'
+
+  const router = FindMyWay({ constraints: { erroring: erroringConstraint, erroring2: erroringConstraint2 } })
+  router.on('GET', '/', { constraints: { erroring: 'a', erroring2: 'b' } }, () => 'handler')
+
+  let callCount = 0
+  router.lookup(
+    {
+      method: 'GET',
+      url: '/',
+      headers: {}
+    },
+    null,
+    (err, result) => {
+      callCount++
+      t.assert.deepStrictEqual(err, new Error('boom'))
+      t.assert.equal(result, undefined)
+    }
+  )
+
+  setTimeout(() => {
+    t.assert.equal(callCount, 1)
+    testDone()
+  }, 50)
+})
+
 test('should derive sync and async constraints', t => {
   t.plan(4)
 


### PR DESCRIPTION
When multiple async constraint strategies are in use and more than one calls back with an error, `deriveAsyncConstraints` would invoke the `done` callback once per error. Track an `errored` flag so the first error short-circuits subsequent callbacks and `done` is only invoked once.