### PR TITLE
fix: preserve unrecognized %XX sequences in safeDecodeURIComponent

### DIFF
--- a/lib/url-sanitizer.js
+++ b/lib/url-sanitizer.js
@@ -94,7 +94,7 @@ function safeDecodeURIComponent (uriComponent) {
       const lowCharCode = uriComponent.charCodeAt(i + 2)
 
       const decodedChar = decodeComponentChar(highCharCode, lowCharCode)
-      decoded += uriComponent.slice(lastIndex, i) + decodedChar
+      decoded += uriComponent.slice(lastIndex, i) + (decodedChar !== null ? decodedChar : uriComponent.slice(i, i + 3))
 
       lastIndex = i + 3
     }

--- a/test/issue-330.test.js
+++ b/test/issue-330.test.js
@@ -158,10 +158,16 @@ test('getMatchingHandler should return null if not compiled', (t) => {
   t.assert.equal(handlerStorage.getMatchingHandler({ foo: 'bar' }), null)
 })
 
-test('safeDecodeURIComponent should replace %3x to null for every x that is not a valid lowchar', (t) => {
+test('safeDecodeURIComponent should preserve %3x for every x that is not a valid lowchar', (t) => {
   t.plan(1)
 
-  t.assert.equal(safeDecodeURIComponent('Hello%3xWorld'), 'HellonullWorld')
+  t.assert.equal(safeDecodeURIComponent('Hello%3xWorld'), 'Hello%3xWorld')
+})
+
+test('safeDecodeURIComponent should preserve unrecognized %XX sequences (e.g. double-encoded %2520)', (t) => {
+  t.plan(1)
+
+  t.assert.equal(safeDecodeURIComponent('%20'), '%20')
 })
 
 test('SemVerStore version should be a string', (t) => {


### PR DESCRIPTION
`decodeComponentChar` returns `null` for percent-encoded sequences that are not reserved characters. Previously, `safeDecodeURIComponent` concatenated this `null` directly, producing the literal string `"null"` in the decoded output (e.g. a double-encoded `%2520` became `"null"` after `safeDecodeURI`/`safeDecodeURIComponent`). Fall back to the original `%XX` substring when decoding is not applicable.