### PR TITLE
fix: backtrack on regex param mismatch

### DIFF
--- a/benchmark/compare-branches.js
+++ b/benchmark/compare-branches.js
@@ -2,7 +2,7 @@
 
 const { spawn } = require('child_process')
 
-const chalk = require('chalk')
+const { default: chalk } = require('chalk')
 const inquirer = require('inquirer')
 const simpleGit = require('simple-git')
 
@@ -25,10 +25,10 @@ async function selectBranchName (message, branches) {
 }
 
 async function executeCommandOnBranch (command, branch) {
-  console.log(chalk.grey(`Checking out "${branch}"`))
+  console.log(chalk.gray(`Checking out "${branch}"`))
   await git.checkout(branch)
 
-  console.log(chalk.grey(`Execute "${command}"`))
+  console.log(chalk.gray(`Execute "${command}"`))
   const childProcess = spawn(command, { stdio: 'pipe', shell: true })
 
   let result = ''

--- a/index.js
+++ b/index.js
@@ -611,17 +611,6 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
   const brothersNodesStack = []
   let maxParamLengthExceeded = false
 
-  const backtrack = () => {
-    if (brothersNodesStack.length === 0) {
-      return null
-    }
-
-    const brotherNodeState = brothersNodesStack.pop()
-    pathIndex = brotherNodeState.brotherPathIndex
-    params.splice(brotherNodeState.paramsCount)
-    return brotherNodeState.brotherNode
-  }
-
   while (true) {
     if (pathIndex === pathLen && currentNode.isLeafNode) {
       const handle = currentNode.handlerStorage.getMatchingHandler(derivedConstraints)
@@ -638,13 +627,17 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
     let node = currentNode.getNextNode(path, pathIndex, brothersNodesStack, params.length)
 
     if (node === null) {
-      node = backtrack()
-      if (node === null) {
+      if (brothersNodesStack.length === 0) {
         if (maxParamLengthExceeded && this.onMaxParamLength) {
           return this._onMaxParamLength(originPath)
         }
         return null
       }
+
+      const brotherNodeState = brothersNodesStack.pop()
+      pathIndex = brotherNodeState.brotherPathIndex
+      params.splice(brotherNodeState.paramsCount)
+      node = brotherNodeState.brotherNode
     }
 
     currentNode = node
@@ -681,13 +674,17 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
       if (currentNode.isRegex) {
         const matchedParameters = currentNode.regex.exec(param)
         if (matchedParameters === null) {
-          currentNode = backtrack()
-          if (currentNode === null) {
+          if (brothersNodesStack.length === 0) {
             if (maxParamLengthExceeded && this.onMaxParamLength) {
               return this._onMaxParamLength(originPath)
             }
             return null
           }
+
+          const brotherNodeState = brothersNodesStack.pop()
+          pathIndex = brotherNodeState.brotherPathIndex
+          params.splice(brotherNodeState.paramsCount)
+          currentNode = brotherNodeState.brotherNode
           continue
         }
 
@@ -702,13 +699,17 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
 
         if (regexMaxParamLengthExceeded) {
           maxParamLengthExceeded = true
-          currentNode = backtrack()
-          if (currentNode === null) {
+          if (brothersNodesStack.length === 0) {
             if (this.onMaxParamLength) {
               return this._onMaxParamLength(originPath)
             }
             return null
           }
+
+          const brotherNodeState = brothersNodesStack.pop()
+          pathIndex = brotherNodeState.brotherPathIndex
+          params.splice(brotherNodeState.paramsCount)
+          currentNode = brotherNodeState.brotherNode
           continue
         }
 
@@ -718,13 +719,17 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
       } else {
         if (param.length > maxParamLength) {
           maxParamLengthExceeded = true
-          currentNode = backtrack()
-          if (currentNode === null) {
+          if (brothersNodesStack.length === 0) {
             if (this.onMaxParamLength) {
               return this._onMaxParamLength(originPath)
             }
             return null
           }
+
+          const brotherNodeState = brothersNodesStack.pop()
+          pathIndex = brotherNodeState.brotherPathIndex
+          params.splice(brotherNodeState.paramsCount)
+          currentNode = brotherNodeState.brotherNode
           continue
         }
         params.push(param)

--- a/index.js
+++ b/index.js
@@ -611,6 +611,17 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
   const brothersNodesStack = []
   let maxParamLengthExceeded = false
 
+  const backtrack = () => {
+    if (brothersNodesStack.length === 0) {
+      return null
+    }
+
+    const brotherNodeState = brothersNodesStack.pop()
+    pathIndex = brotherNodeState.brotherPathIndex
+    params.splice(brotherNodeState.paramsCount)
+    return brotherNodeState.brotherNode
+  }
+
   while (true) {
     if (pathIndex === pathLen && currentNode.isLeafNode) {
       const handle = currentNode.handlerStorage.getMatchingHandler(derivedConstraints)
@@ -627,84 +638,101 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
     let node = currentNode.getNextNode(path, pathIndex, brothersNodesStack, params.length)
 
     if (node === null) {
-      if (brothersNodesStack.length === 0) {
+      node = backtrack()
+      if (node === null) {
         if (maxParamLengthExceeded && this.onMaxParamLength) {
           return this._onMaxParamLength(originPath)
         }
         return null
       }
-
-      const brotherNodeState = brothersNodesStack.pop()
-      pathIndex = brotherNodeState.brotherPathIndex
-      params.splice(brotherNodeState.paramsCount)
-      node = brotherNodeState.brotherNode
     }
 
     currentNode = node
 
-    // static route
-    if (currentNode.kind === NODE_TYPES.STATIC) {
-      pathIndex += currentNode.prefix.length
-      continue
-    }
+    while (true) {
+      // static route
+      if (currentNode.kind === NODE_TYPES.STATIC) {
+        pathIndex += currentNode.prefix.length
+        break
+      }
 
-    if (currentNode.kind === NODE_TYPES.WILDCARD) {
-      let param = originPath.slice(pathIndex)
+      if (currentNode.kind === NODE_TYPES.WILDCARD) {
+        let param = originPath.slice(pathIndex)
+        if (shouldDecodeParam) {
+          param = safeDecodeURIComponent(param)
+        }
+
+        params.push(param)
+        pathIndex = pathLen
+        break
+      }
+
+      // parametric node
+      let paramEndIndex = originPath.indexOf('/', pathIndex)
+      if (paramEndIndex === -1) {
+        paramEndIndex = pathLen
+      }
+
+      let param = originPath.slice(pathIndex, paramEndIndex)
       if (shouldDecodeParam) {
         param = safeDecodeURIComponent(param)
       }
 
-      params.push(param)
-      pathIndex = pathLen
-      continue
-    }
-
-    // parametric node
-    let paramEndIndex = originPath.indexOf('/', pathIndex)
-    if (paramEndIndex === -1) {
-      paramEndIndex = pathLen
-    }
-
-    let param = originPath.slice(pathIndex, paramEndIndex)
-    if (shouldDecodeParam) {
-      param = safeDecodeURIComponent(param)
-    }
-
-    if (currentNode.isRegex) {
-      const matchedParameters = currentNode.regex.exec(param)
-      if (matchedParameters === null) {
-        node = null
-        continue
-      }
-
-      let regexMaxParamLengthExceeded = false
-      for (let i = 1; i < matchedParameters.length; i++) {
-        const matchedParam = matchedParameters[i]
-        if (matchedParam.length > maxParamLength) {
-          regexMaxParamLengthExceeded = true
-          break
+      if (currentNode.isRegex) {
+        const matchedParameters = currentNode.regex.exec(param)
+        if (matchedParameters === null) {
+          currentNode = backtrack()
+          if (currentNode === null) {
+            if (maxParamLengthExceeded && this.onMaxParamLength) {
+              return this._onMaxParamLength(originPath)
+            }
+            return null
+          }
+          continue
         }
+
+        let regexMaxParamLengthExceeded = false
+        for (let i = 1; i < matchedParameters.length; i++) {
+          const matchedParam = matchedParameters[i]
+          if (matchedParam.length > maxParamLength) {
+            regexMaxParamLengthExceeded = true
+            break
+          }
+        }
+
+        if (regexMaxParamLengthExceeded) {
+          maxParamLengthExceeded = true
+          currentNode = backtrack()
+          if (currentNode === null) {
+            if (this.onMaxParamLength) {
+              return this._onMaxParamLength(originPath)
+            }
+            return null
+          }
+          continue
+        }
+
+        for (let i = 1; i < matchedParameters.length; i++) {
+          params.push(matchedParameters[i])
+        }
+      } else {
+        if (param.length > maxParamLength) {
+          maxParamLengthExceeded = true
+          currentNode = backtrack()
+          if (currentNode === null) {
+            if (this.onMaxParamLength) {
+              return this._onMaxParamLength(originPath)
+            }
+            return null
+          }
+          continue
+        }
+        params.push(param)
       }
 
-      if (regexMaxParamLengthExceeded) {
-        maxParamLengthExceeded = true
-        node = null
-        continue
-      }
-
-      for (let i = 1; i < matchedParameters.length; i++) {
-        params.push(matchedParameters[i])
-      }
-    } else {
-      if (param.length > maxParamLength) {
-        maxParamLengthExceeded = true
-        node = null
-        continue
-      }
-      params.push(param)
+      pathIndex = paramEndIndex
+      break
     }
-
-    pathIndex = paramEndIndex
   }
 }
 

--- a/test/issue-6700.test.js
+++ b/test/issue-6700.test.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const { test } = require('node:test')
+const FindMyWay = require('../')
+
+test('regex param route should not match an empty trailing segment', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay({
+    defaultRoute: () => {
+      t.assert.ok('route not matched')
+    }
+  })
+
+  findMyWay.on('GET', '/users/:userId(^\\d+)', () => {
+    t.assert.fail('regex route matched')
+  })
+
+  findMyWay.lookup({ method: 'GET', url: '/users/', headers: {} }, null)
+})
+
+test('find should return null for regex param route with an empty trailing segment', t => {
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/users/:userId(^\\d+)', () => {})
+
+  t.assert.equal(findMyWay.find('GET', '/users/'), null)
+})


### PR DESCRIPTION
## Summary

Fix regex param routes so they do not match requests with an empty trailing segment.

For example, `/users/:userId(^\\d+)` should not match `/users/`.

## Changes

- add a regression test for the empty trailing segment case
- backtrack when a regex param candidate fails to match instead of leaving lookup on the failed leaf node
- preserve existing fallback behavior for sibling parametric and wildcard routes

## Validation

- `npm test`

## Related

- fastify/fastify#6700
