### PR TITLE
fix: apply root path fallback for optional params in off()

### DIFF
--- a/index.js
+++ b/index.js
@@ -487,7 +487,7 @@ Router.prototype.off = function off (method, path, constraints) {
     assert(path.length === optionalParamMatch.index + optionalParamMatch[0].length, 'Optional Parameter needs to be the last parameter of the path')
 
     const pathFull = path.replace(OPTIONAL_PARAM_REGEXP, '$1$2')
-    const pathOptional = path.replace(OPTIONAL_PARAM_REGEXP, '$2')
+    const pathOptional = path.replace(OPTIONAL_PARAM_REGEXP, '$2') || '/'
 
     this.off(method, pathFull, constraints)
     this.off(method, pathOptional, constraints)

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -214,3 +214,18 @@ test('optional parameter on root', (t) => {
   findMyWay.lookup({ method: 'GET', url: '/', headers: {} }, null)
   findMyWay.lookup({ method: 'GET', url: '/foo', headers: {} }, null)
 })
+
+test('off should remove root optional param route', (t) => {
+  const findMyWay = FindMyWay()
+  const noop = () => {}
+
+  findMyWay.on('GET', '/:id?', noop)
+
+  t.assert.notEqual(findMyWay.find('GET', '/'), null)
+  t.assert.notEqual(findMyWay.find('GET', '/123'), null)
+
+  findMyWay.off('GET', '/:id?')
+
+  t.assert.equal(findMyWay.find('GET', '/'), null)
+  t.assert.equal(findMyWay.find('GET', '/123'), null)
+})


### PR DESCRIPTION
## Problem

There is an inconsistency between how optional parameters are expanded in `on()` and `off()`.

When registering a route like `/:id?`, `on()` expands it into both `/:id` and `/`. However, `off()` does not mirror this behavior consistently.

In some edge cases, this may lead to `off()` being invoked with an empty path (`''`), which violates the path validation (`path.length > 0`).

---

## Root Cause

This behavior was already fixed for `on()` in commit cce5437 (#367), but `off()` was not updated with the same fallback:

```js
// on() — correct
const pathOptional = path.replace(OPTIONAL_PARAM_REGEXP, '$2') || '/'
```

```js
// off() — missing fallback
const pathOptional = path.replace(OPTIONAL_PARAM_REGEXP, '$2')
```

---

## Fix

Apply the same fallback used in `on()`:

```js
const pathOptional = path.replace(OPTIONAL_PARAM_REGEXP, '$2') || '/'
```

This ensures that optional parameters resolving to root (`''`) are normalized to `/` in both cases.

---

## Reproduction

```js
const findMyWay = require('find-my-way')()

findMyWay.on('GET', '/:id?', () => {})

findMyWay.off('GET', '/:id?')
```

---

## Result

`off()` becomes consistent with `on()` and correctly handles optional parameters that resolve to root.