### PR TITLE
fix: return limitExceeded objext when maxParamLength is exceeded

### DIFF
--- a/index.js
+++ b/index.js
@@ -672,13 +672,13 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
       for (let i = 1; i < matchedParameters.length; i++) {
         const matchedParam = matchedParameters[i]
         if (matchedParam.length > maxParamLength) {
-          return null
+          return { limitExceeded: true }
         }
         params.push(matchedParam)
       }
     } else {
       if (param.length > maxParamLength) {
-        return null
+        return { limitExceeded: true }
       }
       params.push(param)
     }

--- a/index.js
+++ b/index.js
@@ -672,13 +672,13 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
       for (let i = 1; i < matchedParameters.length; i++) {
         const matchedParam = matchedParameters[i]
         if (matchedParam.length > maxParamLength) {
-          return { limitExceeded: true }
+          return new Error('Parameter length exceeds the maximum allowed length')
         }
         params.push(matchedParam)
       }
     } else {
       if (param.length > maxParamLength) {
-        return { limitExceeded: true }
+        return new Error('Parameter length exceeds the maximum allowed length')
       }
       params.push(param)
     }

--- a/test/issue-330.test.js
+++ b/test/issue-330.test.js
@@ -83,7 +83,7 @@ test('does not find the route if maxParamLength is exceeded', t => {
 
   findMyWay.on('GET', '/:id(\\d+)', () => {})
 
-  t.assert.deepEqual(findMyWay.find('GET', '/123'), { limitExceeded: true })
+  t.assert.deepEqual(findMyWay.find('GET', '/123'), new Error('Parameter length exceeds the maximum allowed length'))
   t.assert.ok(findMyWay.find('GET', '/12'))
 })
 

--- a/test/issue-330.test.js
+++ b/test/issue-330.test.js
@@ -83,7 +83,7 @@ test('does not find the route if maxParamLength is exceeded', t => {
 
   findMyWay.on('GET', '/:id(\\d+)', () => {})
 
-  t.assert.equal(findMyWay.find('GET', '/123'), null)
+  t.assert.deepEqual(findMyWay.find('GET', '/123'), { limitExceeded: true })
   t.assert.ok(findMyWay.find('GET', '/12'))
 })
 

--- a/test/max-param-length-414.test.js
+++ b/test/max-param-length-414.test.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const { test } = require('node:test')
+const FindMyWay = require('../')
+
+test('should return limit exceeded instead of null when param exceeds param length', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay({})
+
+  findMyWay.on('GET', '/user/:id', (req, res, params) => {})
+
+  const shortParam = findMyWay.find('GET', '/user/sai')
+  const longParam = findMyWay.find('GET', '/user/' + 'a'.repeat(101))
+
+  t.assert.ok(shortParam, 'Short parameter should match the route')
+  t.assert.deepEqual(longParam, { limitExceeded: true }, 'Long parameter should return limit exceeded')
+})

--- a/test/max-param-length-414.test.js
+++ b/test/max-param-length-414.test.js
@@ -13,5 +13,5 @@ test('should return limit exceeded instead of null when param exceeds param leng
   const longParam = findMyWay.find('GET', '/user/' + 'a'.repeat(101))
 
   t.assert.ok(shortParam, 'Short parameter should match the route')
-  t.assert.deepEqual(longParam, { limitExceeded: true }, 'Long parameter should return limit exceeded')
+  t.assert.ok(longParam instanceof Error, 'Long parameter should return an error')
 })

--- a/test/max-param-length.test.js
+++ b/test/max-param-length.test.js
@@ -15,7 +15,7 @@ test('maxParamLength should set the maximum length for a parametric route', t =>
 
   const findMyWay = FindMyWay({ maxParamLength: 10 })
   findMyWay.on('GET', '/test/:param', () => {})
-  t.assert.deepEqual(findMyWay.find('GET', '/test/123456789abcd'), { limitExceeded: true })
+  t.assert.deepEqual(findMyWay.find('GET', '/test/123456789abcd'), new Error('Parameter length exceeds the maximum allowed length'))
 })
 
 test('maxParamLength should set the maximum length for a parametric (regex) route', t => {

--- a/test/max-param-length.test.js
+++ b/test/max-param-length.test.js
@@ -15,7 +15,7 @@ test('maxParamLength should set the maximum length for a parametric route', t =>
 
   const findMyWay = FindMyWay({ maxParamLength: 10 })
   findMyWay.on('GET', '/test/:param', () => {})
-  t.assert.deepEqual(findMyWay.find('GET', '/test/123456789abcd'), null)
+  t.assert.deepEqual(findMyWay.find('GET', '/test/123456789abcd'), { limitExceeded: true })
 })
 
 test('maxParamLength should set the maximum length for a parametric (regex) route', t => {


### PR DESCRIPTION
## Problem
When a URL parameter exceeds `maxParamLength`, the router returns `null`.
Fastify interprets this as route not found (404) instead of URI Too Long (414).
Related: fastify/fastify#6697

## Fix
Changed `return null` to `return { limitExceeded: true }` in both 
maxParamLength checks in index.js (lines 675 and 681).
This allows Fastify to distinguish between "not found" and "param too long"
and respond with the correct 414 status code.

## Changes
- index.js: return { limitExceeded: true } instead of null
- test/issue-330.test.js: updated assertion to match new behaviour
- test/max-param-length.test.js: updated assertion to match new behaviour
- test/max-param-length-414.test.js: new test for this specific fix