### PR TITLE
fix: ensure parametric routes require at least one character (#422)

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -156,7 +156,7 @@ class StaticNode extends ParentNode {
     let parametricBrotherNodeIndex = 0
 
     if (node === null) {
-      if (this.parametricChildren.length === 0) {
+      if (this.parametricChildren.length === 0 || pathIndex === path.length) {
         return this.wildcardChild
       }
 

--- a/test/issue-104.test.js
+++ b/test/issue-104.test.js
@@ -137,7 +137,7 @@ test('Mixed routes, url with parameter common prefix > 1', t => {
   t.assert.deepEqual(findMyWay.find('GET', '/test/hello').params, {})
   t.assert.deepEqual(findMyWay.find('GET', '/test/hello/test').params, {})
   t.assert.deepEqual(findMyWay.find('GET', '/te/hello').params, { a: 'hello' })
-  t.assert.deepEqual(findMyWay.find('GET', '/te/').params, { a: '' })
+  t.assert.strictEqual(findMyWay.find('GET', '/te/'), null)
   t.assert.deepEqual(findMyWay.find('GET', '/testy').params, { c: 'testy' })
   t.assert.deepEqual(findMyWay.find('GET', '/besty').params, { c: 'besty' })
   t.assert.deepEqual(findMyWay.find('GET', '/text/hellos/test').params, { e: 'hellos' })

--- a/test/issue-20.test.js
+++ b/test/issue-20.test.js
@@ -67,12 +67,12 @@ test('Should get an empty parameter', t => {
   t.plan(1)
   const findMyWay = FindMyWay({
     defaultRoute: (req, res) => {
-      t.assert.fail('We should not be here')
+      t.assert.ok(true, 'Called defaultRoute')
     }
   })
 
   findMyWay.on('GET', '/a/:param', (req, res, params) => {
-    t.assert.equal(params.param, '')
+    t.assert.fail('We should not be here')
   })
 
   findMyWay.lookup({ method: 'GET', url: '/a/', headers: {} }, null)

--- a/test/issue-422.test.js
+++ b/test/issue-422.test.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const FindMyWay = require('../')
+
+test('parametric route /:id should not match /', (t) => {
+  let defaultRouteCalled = false
+  const router = FindMyWay({
+    defaultRoute: (req, res) => {
+      defaultRouteCalled = true
+    }
+  })
+
+  router.on('GET', '/:id', (req, res, params) => {
+    console.log('Params:', params)
+  })
+
+  router.lookup({ method: 'GET', url: '/' }, {})
+  assert.strictEqual(defaultRouteCalled, true, 'defaultRoute should be called')
+})

--- a/test/optional-params.test.js
+++ b/test/optional-params.test.js
@@ -104,13 +104,13 @@ test('Optional Parameter with ignoreTrailingSlash = false', (t) => {
   const findMyWay = FindMyWay({
     ignoreTrailingSlash: false,
     defaultRoute: (req, res) => {
-      t.assert.equal(req.url, '/test/hello/foo/')
+      t.assert.ok(true, 'Called defaultRoute')
     }
   })
 
   findMyWay.on('GET', '/test/hello/:optional?', (req, res, params) => {
     if (req.url === '/test/hello/') {
-      t.assert.deepEqual(params, { optional: '' })
+      t.assert.fail('Should not be here')
     } else if (req.url === '/test/hello') {
       t.assert.deepEqual(params, {})
     } else if (req.url === '/test/hello/foo') {


### PR DESCRIPTION
This PR fixes issue #422 where parametric routes (e.g. `/:id`) incorrectly matched the root path (`/`) with an empty parameter.

### Changes:
- Modified `getNextNode` in `lib/node.js` to ensure parametric children are only considered if there are characters remaining in the path.
- Updated tests to reflect this change. Parametric routes now require at least one character to match.
- Users who need to match empty values should use optional parameters (e.g. `/:id?`) or `ignoreTrailingSlash: true` if the empty value is represented by a trailing slash.

This aligns the behavior with modern HTTP routing standards and prevents unexpected matches to the root path when only parametric routes are registered.

Fixes #422