### PR TITLE
perf: avoid inner function allocation in _off method

### DIFF
--- a/index.js
+++ b/index.js
@@ -514,18 +514,16 @@ Router.prototype._off = function _off (method, path, constraints) {
   assert(typeof method === 'string', 'Method should be a string')
   assert(httpMethods.includes(method), `Method '${method}' is not an http method.`)
 
-  function matcherWithoutConstraints (route) {
-    return method !== route.method || path !== route.path
-  }
-
-  function matcherWithConstraints (route) {
-    return matcherWithoutConstraints(route) || !deepEqual(constraints, route.opts.constraints || {})
-  }
-
-  const predicate = constraints ? matcherWithConstraints : matcherWithoutConstraints
-
   // Rebuild tree without the specific route
-  const newRoutes = this.routes.filter(predicate)
+  const newRoutes = constraints
+    ? this.routes.filter(route =>
+      method !== route.method ||
+        path !== route.path ||
+        !deepEqual(constraints, route.opts.constraints || {})
+    )
+    : this.routes.filter(route =>
+      method !== route.method || path !== route.path
+    )
   this._rebuild(newRoutes)
 }
 


### PR DESCRIPTION
## Summary

In `_off`, two named functions (`matcherWithoutConstraints` and
`matcherWithConstraints`) were declared inside the function body.
In JavaScript, every function declaration inside another function
creates a new function object on the heap on each call.

These two allocations were unnecessary since the same logic can
be expressed inline with the `filter` callback, which already
requires a closure to capture `method`, `path`, and `constraints`.

## Change

Replaced the two inner function declarations with inline arrow
functions passed directly to `Array.prototype.filter`.

## Before

```js
function matcherWithoutConstraints (route) {
  return method !== route.method || path !== route.path
}

function matcherWithConstraints (route) {
  return matcherWithoutConstraints(route) || !deepEqual(constraints, route.opts.constraints || {})
}

const predicate = constraints ? matcherWithConstraints : matcherWithoutConstraints
const newRoutes = this.routes.filter(predicate)
```

## After

```js
const newRoutes = constraints
  ? this.routes.filter(route =>
      method !== route.method ||
      path !== route.path ||
      !deepEqual(constraints, route.opts.constraints || {})
    )
  : this.routes.filter(route =>
      method !== route.method || path !== route.path
    )
```

## Result

- 2 heap allocations → 1 per `_off` call
- Fewer objects for GC to collect
- Code is shorter and easier to follow