### PR TITLE
ci: add node v26 to test matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,6 +21,7 @@ jobs:
           - 20
           - 22
           - 24
+          - 26
         os: 
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
Node.js v26 has been released. This PR adds it to the CI test matrix.

Tested locally on Node.js 26 — all tests pass.

---

> **Note:** Node.js v20 reached End-of-Life on April 30, 2026.  
> Should we drop it from the matrix and bump `engines.node` from `>=20` to `>=22`?
>
> **`package.json`**
> ```json
> "engines": {
>   "node": ">=20"
> }
> ```
>
> **`.github/workflows/node.js.yml`**
> ```yaml
> matrix:
>   node-version:
>     - 20
>     - 22
>     - 24
>     - 26
> ```
>
> Happy to update this PR if you'd like to include that cleanup.