### PR TITLE
perf(host): cache regex lookup results in HostStorage

### DIFF
--- a/lib/strategies/accept-host.js
+++ b/lib/strategies/accept-host.js
@@ -4,21 +4,28 @@ const assert = require('node:assert')
 function HostStorage () {
   const hosts = new Map()
   const regexHosts = []
+  const regexCache = new Map()
   return {
     get: (host) => {
       const exact = hosts.get(host)
       if (exact) {
         return exact
       }
+      if (regexHosts.length === 0) return undefined
+      if (regexCache.has(host)) return regexCache.get(host)
       for (const regex of regexHosts) {
         if (regex.host.test(host)) {
+          regexCache.set(host, regex.value)
           return regex.value
         }
       }
+      regexCache.set(host, undefined)
     },
     set: (host, value) => {
       if (host instanceof RegExp) {
-        regexHosts.push({ host, value })
+        const safeRegex = new RegExp(host.source, host.flags.replace(/[gy]/g, ''))
+        regexHosts.push({ host: safeRegex, value })
+        regexCache.clear()
       } else {
         hosts.set(host, value)
       }

--- a/test/host-storage.test.js
+++ b/test/host-storage.test.js
@@ -25,3 +25,26 @@ test('exact host matches take precendence over regexp matches', async (t) => {
   t.assert.equal(storage.get('bar.fastify.io'), 'wildcard')
   t.assert.equal(storage.get('auth.fastify.io'), 'exact')
 })
+
+test('regex cache is invalidated when a new regexp is added', async (t) => {
+  const storage = acceptHostStrategy.storage()
+  storage.set(/.+fastify\.io/, 'first')
+  t.assert.equal(storage.get('foo.fastify.io'), 'first')
+  t.assert.equal(storage.get('bar.example.com'), undefined)
+  storage.set(/.+example\.com/, 'second')
+  t.assert.equal(storage.get('bar.example.com'), 'second')
+  t.assert.equal(storage.get('foo.fastify.io'), 'first')
+})
+
+test('stateful regex flags (g, y) are stripped to ensure deterministic caching', async (t) => {
+  const storage = acceptHostStrategy.storage()
+  storage.set(/.+fastify\.io/g, 'wildcard')
+  t.assert.equal(storage.get('foo.fastify.io'), 'wildcard')
+  t.assert.equal(storage.get('bar.fastify.io'), 'wildcard')
+  t.assert.equal(storage.get('baz.fastify.io'), 'wildcard')
+  const storage2 = acceptHostStrategy.storage()
+  storage2.set(/.+fastify\.io/y, 'wildcard')
+  t.assert.equal(storage2.get('foo.fastify.io'), 'wildcard')
+  t.assert.equal(storage2.get('bar.fastify.io'), 'wildcard')
+  t.assert.equal(storage2.get('baz.fastify.io'), 'wildcard')
+})


### PR DESCRIPTION
## Problem

Every `get()` call scans all regex patterns from scratch, even for
hosts seen before. In applications with regex-based host constraints,
this becomes a hot path with no reuse.

## Solution

Add a `Map`-based cache inside `HostStorage`. Once a host is matched
(or confirmed unmatched) against the regex list, the result is stored
and returned directly on subsequent calls.

An early-exit guard (`regexHosts.length === 0`) ensures exact-match
paths are completely unaffected.

The cache is invalidated when a new regex route is added via `set()`.

## Benchmark

500 samples, Node.js v26.1.0

| Scenario | Original | Patched | Delta |
|---|---|---|---|
| Exact match only | 38.0M ops/sec | 38.4M ops/sec | ~0% |
| Single regex, repeated host | 13.9M ops/sec | 43.4M ops/sec | +210% |
| Many regexes, finite host pool | 8.1M ops/sec | 34.0M ops/sec | +318% |