### PR TITLE
fix: avoid crash on undefined regex capture during route lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -690,7 +690,7 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
 
         let regexMaxParamLengthExceeded = false
         for (let i = 1; i < matchedParameters.length; i++) {
-          const matchedParam = matchedParameters[i]
+          const matchedParam = matchedParameters[i] ?? ''
           if (matchedParam.length > maxParamLength) {
             regexMaxParamLengthExceeded = true
             break
@@ -714,7 +714,7 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
         }
 
         for (let i = 1; i < matchedParameters.length; i++) {
-          params.push(matchedParameters[i])
+          params.push(matchedParameters[i] ?? '')
         }
       } else {
         if (param.length > maxParamLength) {

--- a/test/regex.test.js
+++ b/test/regex.test.js
@@ -267,3 +267,16 @@ test('prevent back-tracking', { timeout: 20 }, (t) => {
   findMyWay.on('GET', '/:foo-:bar-', (req, res, params) => {})
   findMyWay.find('GET', '/' + '-'.repeat(16000) + 'a', { host: 'fastify.io' })
 })
+
+test('lookup matches empty regex captures', t => {
+  t.plan(1)
+
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/test/:id(^((?!abc).)*$)', (req, res, params) => t.assert.equal(params.id, ''))
+
+  findMyWay.lookup({ method: 'GET', url: '/test/', headers: {} }, {
+    statusCode: 0,
+    end: () => {}
+  })
+})


### PR DESCRIPTION
This PR fixes a runtime crash in regex param route matching when a capture group is undefined.

In some routes using nested or repeated regex groups, a request can produce an undefined capture value while regex matching still succeeds. The lookup path then attempts to read .length from that undefined value, causing a TypeError and crashing the process.

What this PR changes:

1. Normalize regex capture values to empty strings before length checks.
2. Push normalized values into params, so params remain stable and lookup does not throw.

Behavior note:
This change preserves empty-value matching behavior. Empty captures are treated as empty strings rather than non-matches.
