### PR TITLE
fix: keep static parts between parameters in the route pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,6 +206,9 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
       let isParamSafe = true
       let backtrack = ''
       const regexps = []
+      // Canonical form of this node, accumulated one parameter at a time so
+      // static parts between parameters survive into the pattern.
+      let nodePatternParts = ''
 
       let lastParamStartIndex = i + 1
       for (let j = lastParamStartIndex; ; j++) {
@@ -257,9 +260,10 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
           }
 
           lastParamStartIndex = j + 1
+          nodePatternParts += '()' + staticPart
 
           if (isEndOfNode || pattern.charCodeAt(j) === 47 || j === pattern.length) {
-            const nodePattern = isRegexNode ? '()' + staticPart : staticPart
+            const nodePattern = isRegexNode ? nodePatternParts : staticPart
             const nodePath = pattern.slice(i, j)
 
             pattern = pattern.slice(0, i + 1) + nodePattern + pattern.slice(j)
@@ -353,6 +357,9 @@ Router.prototype.findRoute = function findNode (method, path, constraints = {}) 
       let isParamSafe = true
       let backtrack = ''
       const regexps = []
+      // Canonical form of this node, accumulated one parameter at a time so
+      // static parts between parameters survive into the pattern.
+      let nodePatternParts = ''
 
       let lastParamStartIndex = i + 1
       for (let j = lastParamStartIndex; ; j++) {
@@ -404,9 +411,10 @@ Router.prototype.findRoute = function findNode (method, path, constraints = {}) 
           }
 
           lastParamStartIndex = j + 1
+          nodePatternParts += '()' + staticPart
 
           if (isEndOfNode || pattern.charCodeAt(j) === 47 || j === pattern.length) {
-            const nodePattern = isRegexNode ? '()' + staticPart : staticPart
+            const nodePattern = isRegexNode ? nodePatternParts : staticPart
             const nodePath = pattern.slice(i, j)
 
             pattern = pattern.slice(0, i + 1) + nodePattern + pattern.slice(j)

--- a/test/issue-369.test.js
+++ b/test/issue-369.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const { test } = require('node:test')
+const FindMyWay = require('..')
+
+test('routes differing only by a static part between parameters are distinct', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-r:poiId', () => 'r')
+  findMyWay.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-a:poiId', () => 'a')
+
+  t.assert.equal(findMyWay.find('GET', '/h5/city-poi/hotels-cC1-rP1').handler(), 'r')
+  t.assert.equal(findMyWay.find('GET', '/h5/city-poi/hotels-cC1-aP1').handler(), 'a')
+})
+
+test('parameters separated by different static parts do not collide', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/foo/:a-:b', () => 'dash')
+  findMyWay.on('GET', '/foo/:a.:b', () => 'dot')
+
+  t.assert.equal(findMyWay.find('GET', '/foo/x-y').handler(), 'dash')
+  t.assert.equal(findMyWay.find('GET', '/foo/x.y').handler(), 'dot')
+})
+
+test('params are still parsed when a node ends with a parameter', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-r:poiId', () => {})
+
+  t.assert.deepEqual(findMyWay.find('GET', '/h5/city-poi/hotels-cC1-rP1').params, {
+    cityName: 'city',
+    poiName: 'poi',
+    cityId: 'C1',
+    poiId: 'P1'
+  })
+})
+
+test('findRoute distinguishes routes differing only by an interior static part', t => {
+  t.plan(3)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-r:poiId', () => 'r')
+  findMyWay.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-a:poiId', () => 'a')
+
+  t.assert.equal(
+    findMyWay.findRoute('GET', '/h5/:cityName-:poiName/hotels-c:cityId-r:poiId').handler(),
+    'r'
+  )
+  t.assert.equal(
+    findMyWay.findRoute('GET', '/h5/:cityName-:poiName/hotels-c:cityId-a:poiId').handler(),
+    'a'
+  )
+  t.assert.equal(
+    findMyWay.findRoute('GET', '/h5/:cityName-:poiName/hotels-c:cityId-z:poiId'),
+    null
+  )
+})
+
+test('duplicate routes ending with a parameter are still rejected', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/h5/hotels-c:cityId-r:poiId', () => {})
+
+  t.assert.throws(
+    () => findMyWay.on('GET', '/h5/hotels-c:cityId-r:poiId', () => {}),
+    /already declared/
+  )
+})


### PR DESCRIPTION
Fixes #369.

## Reproduction

The report in #369 never got a runnable reproduction, so here is one against `main` (v9.7.0):

```js
const FindMyWay = require('find-my-way')
const router = FindMyWay()

router.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-r:poiId', () => 'r')
router.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-a:poiId', () => 'a')
// Error: Method 'GET' already declared for route '/h5/:()/hotels-c:()' with constraints '{}'
```

The two routes differ in the literal `r` and `a` before the last parameter, so they are distinct routes, but the second registration is rejected as a duplicate.

The same root cause makes these collide too:

```js
router.on('GET', '/foo/:a-:b', () => 'dash')
router.on('GET', '/foo/:a.:b', () => 'dot')   // same error
```

## Cause

When a parametric node is closed, its canonical form is built from the most recent static part only:

```js
const nodePattern = isRegexNode ? '()' + staticPart : staticPart
```

For `:cityId-r:poiId` the loop sees two parameters. It records `-r` as the static part of the first, then the second parameter ends the node with an empty static part, so `staticPart` is `''` and the whole node canonicalises to `()`. Every static part between parameters is dropped whenever the node ends with a parameter — which is the diagnosis given in the issue.

The compiled regex is unaffected because it is accumulated across the loop into `regexps`, which is why matching and parameter extraction were always correct. Only pattern identity was wrong, and pattern identity is what the duplicate check at index.js:299 and `findRoute` at index.js:446 compare.

## Fix

Accumulate the canonical form one parameter at a time, so interior static parts survive:

```js
nodePatternParts += '()' + staticPart
...
const nodePattern = isRegexNode ? nodePatternParts : staticPart
```

`/h5/:cityName-:poiName/hotels-c:cityId-r:poiId` now canonicalises to `/h5/:()-()/hotels-c:()-r()` instead of `/h5/:()/hotels-c:()`.

Applied to both `_on` and `findRoute`, which contain the same parsing loop — if only one were changed, registration and lookup would disagree about a route's identity.

`pattern` is compared only against other generated patterns and is not part of the documented API, so the changed canonical form is internal.

## Tests

New `test/issue-369.test.js` covers the reported case, the `-` vs `.` variant, `findRoute` symmetry (including a negative lookup), that parameters still parse correctly, and that genuine duplicates ending in a parameter are still rejected.

Against unmodified `main`, 3 of the 5 fail; the other 2 pass on both and guard against regressing existing behaviour.

- `npx borp` — 519 passing (514 before this branch), 0 failing
- `npx standard` — clean
- `npm run test:typescript` — clean
