### PR TITLE
fix: serialize RegExp values in prettyPrint constraints and meta

### DIFF
--- a/lib/pretty-print.js
+++ b/lib/pretty-print.js
@@ -37,6 +37,7 @@ function parseMeta (meta) {
   if (Array.isArray(meta)) return meta.map(m => parseMeta(m))
   if (typeof meta === 'symbol') return meta.toString()
   if (typeof meta === 'function') return parseFunctionName(meta)
+  if (meta instanceof RegExp) return meta.toString()
   return meta
 }
 
@@ -82,12 +83,19 @@ function normalizeRoute (route) {
   return { ...route, method, opts: { constraints } }
 }
 
+function serializeConstraints (constraints) {
+  return JSON.stringify(constraints, (_key, value) => {
+    if (value instanceof RegExp) return value.toString()
+    return value
+  })
+}
+
 function serializeRoute (route) {
   let serializedRoute = ` (${route.method})`
 
   const constraints = route.opts.constraints || {}
   if (Object.keys(constraints).length !== 0) {
-    serializedRoute += ' ' + JSON.stringify(constraints)
+    serializedRoute += ' ' + serializeConstraints(constraints)
   }
 
   serializedRoute += serializeMetaData(route.metaData)

--- a/test/pretty-print.test.js
+++ b/test/pretty-print.test.js
@@ -678,3 +678,49 @@ SUBSCRIBE, TRACE, UNBIND, UNLINK, UNLOCK, UNSUBSCRIBE)
   t.assert.equal(typeof tree, 'string')
   t.assert.equal(tree, expected)
 })
+
+test('pretty print - regex constraint values are serialized', t => {
+  t.plan(4)
+
+  const findMyWay = FindMyWay()
+  findMyWay.on('GET', '/test', () => {})
+  findMyWay.on('GET', '/test', { constraints: { host: /^auth\..*\.fastify\.io$/ } }, () => {})
+  findMyWay.on('GET', '/test', { constraints: { host: /^admin\..*$/ } }, () => {})
+
+  const radixTree = findMyWay.prettyPrint()
+  const radixExpected = `\
+└── /
+    └── test (GET)
+        test (GET) {"host":"/^auth\\\\..*\\\\.fastify\\\\.io$/"}
+        test (GET) {"host":"/^admin\\\\..*$/"}
+`
+  t.assert.equal(typeof radixTree, 'string')
+  t.assert.equal(radixTree, radixExpected)
+
+  const arrayTree = findMyWay.prettyPrint({ commonPrefix: false })
+  const arrayExpected = `\
+└── /test (GET)
+    /test (GET) {"host":"/^auth\\\\..*\\\\.fastify\\\\.io$/"}
+    /test (GET) {"host":"/^admin\\\\..*$/"}
+`
+  t.assert.equal(typeof arrayTree, 'string')
+  t.assert.equal(arrayTree, arrayExpected)
+})
+
+test('pretty print - regex values in includeMeta are serialized', t => {
+  t.plan(2)
+
+  const findMyWay = FindMyWay({
+    buildPrettyMeta: route => route.store
+  })
+  findMyWay.on('GET', '/x', () => {}, { pattern: /foo/i })
+
+  const tree = findMyWay.prettyPrint({ includeMeta: true })
+  const expected = `\
+└── /
+    └── x (GET)
+        • (pattern) "/foo/i"
+`
+  t.assert.equal(typeof tree, 'string')
+  t.assert.equal(tree, expected)
+})


### PR DESCRIPTION
## What

`prettyPrint()` renders `RegExp` values as `{}` in both route constraints and route metadata.

## Why this matters

The `host` constraint strategy (`lib/strategies/accept-host.js`) accepts both strings and RegExp — it's a documented feature used e.g. for multi-tenant / subdomain-based routing. When you register multiple routes on the same path with different regex host constraints, the debug output currently looks like this:

```js
findMyWay.on('GET', '/users', { constraints: { host: /^auth\..*\.fastify\.io$/ } }, () => {})
findMyWay.on('GET', '/users', { constraints: { host: /^admin\..*$/ } }, () => {})

console.log(findMyWay.prettyPrint())
// └── /
//     └── users (GET) {"host":{}}
//         users (GET) {"host":{}}
```

Three distinct handlers, three identical lines — you can't tell them apart, which defeats the purpose of `prettyPrint()`. Route resolution itself works correctly (`deepEqual` compares regex source + flags), only the human-readable render loses information.

Root cause is `JSON.stringify(regex) === "{}"`.

## The fix

Two small, symmetric changes:

**1. Serialize RegExp constraint values via a `JSON.stringify` replacer.**
Wrapped in a `serializeConstraints` helper so `serializeRoute` stays readable.

**2. Handle `RegExp` in `parseMeta`.**
`parseMeta` already special-cases `symbol` and `function` before falling through to `JSON.stringify`; RegExp was missing from that list, so any regex returned from a user's `buildPrettyMeta` hit the same `{}` problem. The one-line addition keeps `parseMeta` consistent with itself.

After the fix:

```
└── /
    └── users (GET) {"host":"/^auth\\..*\\.fastify\\.io$/"}
        users (GET) {"host":"/^admin\\..*$/"}
```

## Format choice

I went with `RegExp.prototype.toString()` (e.g. `"/^admin\\..*$/"`) because it mirrors the existing `symbol.toString()` / function-name pattern in this file. An alternative would be `{ source, flags }` — more explicit and easier to programmatically parse, but breaks symmetry with the other special-cased types. Happy to switch to that shape if you'd prefer.

## Tests

Two new tests in `test/pretty-print.test.js`:

- `pretty print - regex constraint values are serialized` — covers both `commonPrefix: true` and `commonPrefix: false` paths with regex host constraints.
- `pretty print - regex values in includeMeta are serialized` — covers regex values returned by `buildPrettyMeta`.

Both fail on `main`, both pass with this patch. All 514 existing tests continue to pass. `standard` clean.

## Not touched

- Route resolution behavior — unchanged, this is render-only.
- Non-regex constraint serialization — unchanged.
- Any public API — unchanged.