### PR TITLE
fix(router): keep static segments between params in route patterns

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,6 +206,9 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
       let isParamSafe = true
       let backtrack = ''
       const regexps = []
+      // Canonical form of this node, accumulated one parameter at a time so
+      // static parts between parameters survive into the pattern.
+      let nodePatternParts = ''
 
       let lastParamStartIndex = i + 1
       for (let j = lastParamStartIndex; ; j++) {
@@ -257,9 +260,10 @@ Router.prototype._on = function _on (method, path, opts, handler, store) {
           }
 
           lastParamStartIndex = j + 1
+          nodePatternParts += '()' + staticPart
 
           if (isEndOfNode || pattern.charCodeAt(j) === 47 || j === pattern.length) {
-            const nodePattern = isRegexNode ? '()' + staticPart : staticPart
+            const nodePattern = isRegexNode ? nodePatternParts : staticPart
             const nodePath = pattern.slice(i, j)
 
             pattern = pattern.slice(0, i + 1) + nodePattern + pattern.slice(j)
@@ -353,6 +357,9 @@ Router.prototype.findRoute = function findNode (method, path, constraints = {}) 
       let isParamSafe = true
       let backtrack = ''
       const regexps = []
+      // Canonical form of this node, accumulated one parameter at a time so
+      // static parts between parameters survive into the pattern.
+      let nodePatternParts = ''
 
       let lastParamStartIndex = i + 1
       for (let j = lastParamStartIndex; ; j++) {
@@ -404,9 +411,10 @@ Router.prototype.findRoute = function findNode (method, path, constraints = {}) 
           }
 
           lastParamStartIndex = j + 1
+          nodePatternParts += '()' + staticPart
 
           if (isEndOfNode || pattern.charCodeAt(j) === 47 || j === pattern.length) {
-            const nodePattern = isRegexNode ? '()' + staticPart : staticPart
+            const nodePattern = isRegexNode ? nodePatternParts : staticPart
             const nodePath = pattern.slice(i, j)
 
             pattern = pattern.slice(0, i + 1) + nodePattern + pattern.slice(j)

--- a/test/issue-369.test.js
+++ b/test/issue-369.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const { test } = require('node:test')
+const FindMyWay = require('..')
+
+test('routes differing only by a static part between parameters are distinct', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-r:poiId', () => 'r')
+  findMyWay.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-a:poiId', () => 'a')
+
+  t.assert.equal(findMyWay.find('GET', '/h5/city-poi/hotels-cC1-rP1').handler(), 'r')
+  t.assert.equal(findMyWay.find('GET', '/h5/city-poi/hotels-cC1-aP1').handler(), 'a')
+})
+
+test('parameters separated by different static parts do not collide', t => {
+  t.plan(2)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/foo/:a-:b', () => 'dash')
+  findMyWay.on('GET', '/foo/:a.:b', () => 'dot')
+
+  t.assert.equal(findMyWay.find('GET', '/foo/x-y').handler(), 'dash')
+  t.assert.equal(findMyWay.find('GET', '/foo/x.y').handler(), 'dot')
+})
+
+test('params are still parsed when a node ends with a parameter', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-r:poiId', () => {})
+
+  t.assert.deepEqual(findMyWay.find('GET', '/h5/city-poi/hotels-cC1-rP1').params, {
+    cityName: 'city',
+    poiName: 'poi',
+    cityId: 'C1',
+    poiId: 'P1'
+  })
+})
+
+test('findRoute distinguishes routes differing only by an interior static part', t => {
+  t.plan(3)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-r:poiId', () => 'r')
+  findMyWay.on('GET', '/h5/:cityName-:poiName/hotels-c:cityId-a:poiId', () => 'a')
+
+  t.assert.equal(
+    findMyWay.findRoute('GET', '/h5/:cityName-:poiName/hotels-c:cityId-r:poiId').handler(),
+    'r'
+  )
+  t.assert.equal(
+    findMyWay.findRoute('GET', '/h5/:cityName-:poiName/hotels-c:cityId-a:poiId').handler(),
+    'a'
+  )
+  t.assert.equal(
+    findMyWay.findRoute('GET', '/h5/:cityName-:poiName/hotels-c:cityId-z:poiId'),
+    null
+  )
+})
+
+test('duplicate routes ending with a parameter are still rejected', t => {
+  t.plan(1)
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/h5/hotels-c:cityId-r:poiId', () => {})
+
+  t.assert.throws(
+    () => findMyWay.on('GET', '/h5/hotels-c:cityId-r:poiId', () => {}),
+    /already declared/
+  )
+})


### PR DESCRIPTION
## Summary

Preserves interior static path segments that appear between dynamic parameters when compiling route patterns.

## Why

Dropping interior static segments can route requests incorrectly for mixed static/param patterns.
