### PR TITLE
chore: migrate to ESLint 9 and neostandard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('neostandard')()

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "bench": "node ./benchmark/bench.js",
     "bench:cmp": "node ./benchmark/compare-branches.js",
     "bench:cmp:ci": "node ./benchmark/compare-branches.js --ci",
-    "test:lint": "standard",
+    "test:lint": "eslint .",
     "test:typescript": "tstyche",
-    "test": "standard && borp && npm run test:typescript"
+    "test": "npm run test:lint && borp && npm run test:typescript"
   },
   "repository": {
     "type": "git",
@@ -38,12 +38,13 @@
     "benchmark": "^2.1.4",
     "borp": "^1.0.0",
     "chalk": "^6.0.0",
+    "eslint": "^9.39.5",
     "inquirer": "^14.0.2",
+    "neostandard": "^0.13.0",
     "pre-commit": "^2.0.0",
     "proxyquire": "^2.1.3",
     "rfdc": "^1.3.0",
     "simple-git": "^3.7.1",
-    "standard": "^17.0.0",
     "tstyche": "^7.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- migrate linting from StandardJS to ESLint 9
- use neostandard through an ESLint flat config
- update the lint and test scripts

## Tests

- `npm test`
