### PR TITLE
fix: parse absolute-form request targets safely

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,14 +36,9 @@ const httpMethods = require('./lib/http-methods')
 const httpMethodStrategy = require('./lib/strategies/http-method')
 const { safeDecodeURI, safeDecodeURIComponent, safeDecodeURINativeScan, safeDecodeURICharScan, MIN_NATIVE_SCAN_LENGTH } = require('./lib/url-sanitizer')
 
-const FULL_PATH_REGEXP = /^https?:\/\/.*?\//
 const OPTIONAL_PARAM_REGEXP = /(\/:[^/()]*?)\?(\/?)/
 const ESCAPE_REGEXP = /[.*+?^${}()|[\]\\]/g
 const REMOVE_DUPLICATE_SLASHES_REGEXP = /\/\/+/g
-
-if (!isRegexSafe(FULL_PATH_REGEXP)) {
-  throw new Error('the FULL_PATH_REGEXP is not safe, update this module')
-}
 
 if (!isRegexSafe(OPTIONAL_PARAM_REGEXP)) {
   throw new Error('the OPTIONAL_PARAM_REGEXP is not safe, update this module')
@@ -586,7 +581,11 @@ Router.prototype.find = function find (method, path, derivedConstraints) {
   if (currentNode == null) return null
 
   if (path.charCodeAt(0) !== 47) { // 47 is '/'
-    path = path.replace(FULL_PATH_REGEXP, '/')
+    const absolutePath = getPathFromAbsoluteUrl(path)
+    if (absolutePath === null) {
+      return this._onBadUrl(path)
+    }
+    path = absolutePath
   }
 
   // This must be run before sanitizeUrl as the resulting function
@@ -865,6 +864,54 @@ module.exports = Router
 
 function escapeRegExp (string) {
   return string.replace(ESCAPE_REGEXP, '\\$&')
+}
+
+function getPathFromAbsoluteUrl (url) {
+  const schemeEnd = url.indexOf('://')
+  if (schemeEnd === -1) {
+    return url
+  }
+
+  const scheme = url.slice(0, schemeEnd).toLowerCase()
+  if (scheme !== 'http' && scheme !== 'https') {
+    return url
+  }
+
+  const authorityStart = schemeEnd + 3
+  let authorityEnd = url.length
+
+  const pathStart = url.indexOf('/', authorityStart)
+  if (pathStart !== -1) {
+    authorityEnd = pathStart
+  }
+
+  const queryStart = url.indexOf('?', authorityStart)
+  if (queryStart !== -1 && queryStart < authorityEnd) {
+    authorityEnd = queryStart
+  }
+
+  // Fragments are not valid in an HTTP request target. In particular, do not
+  // allow a slash after one to be interpreted as the start of the path.
+  if (url.indexOf('#', authorityStart) !== -1 || authorityEnd === authorityStart) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== `${scheme}:` || parsed.host.length === 0) {
+      return null
+    }
+  } catch (error) {
+    return null
+  }
+
+  if (authorityEnd === url.length) {
+    return '/'
+  }
+  if (authorityEnd === queryStart) {
+    return '/' + url.slice(queryStart)
+  }
+  return url.slice(pathStart)
 }
 
 function removeDuplicateSlashes (path) {

--- a/test/full-url.test.js
+++ b/test/full-url.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { test } = require('node:test')
+const http = require('node:http')
 const FindMyWay = require('../')
 
 test('full-url', t => {
@@ -9,6 +10,12 @@ test('full-url', t => {
       t.assert.fail('Should not be defaultRoute')
     }
   })
+
+  const rootHandler = () => {}
+  const adminHandler = () => {}
+
+  findMyWay.on('GET', '/', rootHandler)
+  findMyWay.on('GET', '/admin', adminHandler)
 
   findMyWay.on('GET', '/a', (req, res) => {
     res.end('{"message":"hello world"}')
@@ -27,4 +34,110 @@ test('full-url', t => {
   t.assert.deepEqual(findMyWay.find('GET', 'http://localhost:8080/a/100', { host: 'localhost' }), findMyWay.find('GET', '/a/100', { host: 'localhost' }))
   t.assert.deepEqual(findMyWay.find('GET', 'http://123.123.123.123/a/100', {}), findMyWay.find('GET', '/a/100', {}))
   t.assert.deepEqual(findMyWay.find('GET', 'https://localhost/a/100', { host: 'localhost' }), findMyWay.find('GET', '/a/100', { host: 'localhost' }))
+
+  for (const url of [
+    'http://localhost?next=/admin',
+    'https://localhost?next=/admin',
+    'HTTP://localhost?next=/admin'
+  ]) {
+    const match = findMyWay.find('GET', url, { host: 'localhost' })
+    t.assert.equal(match.handler, rootHandler)
+    t.assert.notEqual(match.handler, adminHandler)
+    t.assert.deepEqual(match.searchParams, { next: '/admin' })
+  }
+
+  t.assert.deepEqual(
+    findMyWay.find('GET', 'http://localhost?next=//admin/settings&return=/', { host: 'localhost' }),
+    findMyWay.find('GET', '/?next=//admin/settings&return=/', { host: 'localhost' })
+  )
+  t.assert.deepEqual(
+    findMyWay.find('GET', 'http://localhost/?next=/admin', { host: 'localhost' }),
+    findMyWay.find('GET', '/?next=/admin', { host: 'localhost' })
+  )
+  t.assert.deepEqual(
+    findMyWay.find('GET', 'http://localhost', { host: 'localhost' }),
+    findMyWay.find('GET', '/', { host: 'localhost' })
+  )
+})
+
+test('lookup preserves the query of an absolute-form target with an empty path', t => {
+  const findMyWay = FindMyWay()
+
+  findMyWay.on('GET', '/', (req, res, params, store, searchParams) => searchParams)
+  findMyWay.on('GET', '/admin', () => {
+    t.assert.fail('query data must not select the admin route')
+  })
+
+  const searchParams = findMyWay.lookup({
+    method: 'GET',
+    url: 'http://example.test?next=/admin',
+    headers: { host: 'example.test' }
+  }, null)
+
+  t.assert.deepEqual(searchParams, { next: '/admin' })
+})
+
+test('an HTTP server routes an absolute-form target with an empty path to root', async t => {
+  const findMyWay = FindMyWay()
+  const requestTarget = 'http://example.test?next=/admin'
+
+  findMyWay.on('GET', '/', (req, res, params, store, searchParams) => {
+    t.assert.equal(req.url, requestTarget)
+    res.end(JSON.stringify({ route: 'root', searchParams }))
+  })
+  findMyWay.on('GET', '/admin', (req, res) => {
+    res.end(JSON.stringify({ route: 'admin' }))
+  })
+
+  const server = http.createServer((req, res) => findMyWay.lookup(req, res))
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  t.after(() => new Promise(resolve => server.close(resolve)))
+
+  const response = await new Promise((resolve, reject) => {
+    const req = http.request({
+      host: '127.0.0.1',
+      port: server.address().port,
+      path: requestTarget,
+      headers: { host: 'example.test' }
+    }, res => {
+      let body = ''
+      res.setEncoding('utf8')
+      res.on('data', chunk => { body += chunk })
+      res.on('end', () => resolve({ statusCode: res.statusCode, body }))
+    })
+    req.on('error', reject)
+    req.end()
+  })
+
+  t.assert.equal(response.statusCode, 200)
+  t.assert.deepEqual(JSON.parse(response.body), {
+    route: 'root',
+    searchParams: { next: '/admin' }
+  })
+})
+
+test('invalid HTTP absolute-form targets use the bad URL handler', t => {
+  let badUrl
+  const findMyWay = FindMyWay({
+    onBadUrl: url => {
+      badUrl = url
+    }
+  })
+
+  findMyWay.on('GET', '/admin', () => {
+    t.assert.fail('an invalid absolute-form target must not select the admin route')
+  })
+
+  for (const url of [
+    'http:///admin',
+    'http://localhost#next=/admin',
+    'http://localhost:invalid/admin'
+  ]) {
+    const match = findMyWay.find('GET', url)
+    findMyWay.callHandler(match, null, null)
+    t.assert.equal(badUrl, url)
+  }
 })

--- a/test/issue-330.test.js
+++ b/test/issue-330.test.js
@@ -7,28 +7,17 @@ const { safeDecodeURIComponent } = require('../lib/url-sanitizer')
 const acceptVersionStrategy = require('../lib/strategies/accept-version')
 const httpMethodStrategy = require('../lib/strategies/http-method')
 
-test('FULL_PATH_REGEXP and OPTIONAL_PARAM_REGEXP should be considered safe', (t) => {
+test('OPTIONAL_PARAM_REGEXP should be considered safe', (t) => {
   t.plan(1)
 
   t.assert.doesNotThrow(() => require('..'))
 })
 
-test('should throw an error for unsafe FULL_PATH_REGEXP', (t) => {
+test('Should throw an error for unsafe OPTIONAL_PARAM_REGEXP', (t) => {
   t.plan(1)
 
   t.assert.throws(() => proxyquire('..', {
     'safe-regex2': () => false
-  }), new Error('the FULL_PATH_REGEXP is not safe, update this module'))
-})
-
-test('Should throw an error for unsafe OPTIONAL_PARAM_REGEXP', (t) => {
-  t.plan(1)
-
-  let callCount = 0
-  t.assert.throws(() => proxyquire('..', {
-    'safe-regex2': () => {
-      return ++callCount < 2
-    }
   }), new Error('the OPTIONAL_PARAM_REGEXP is not safe, update this module'))
 })
 


### PR DESCRIPTION
## Summary

- replace regex-based absolute-form path extraction with component-aware HTTP(S) URL handling
- normalize an empty absolute-form path to `/` without treating query slashes as path data
- preserve the original query string and route invalid absolute-form targets through `onBadUrl`
- cover direct lookup, router dispatch, and a real Node.js HTTP server request

## Validation

- `npm test`
- `git diff --check`
